### PR TITLE
feat: add media gallery button and template selection to Digital Screen settings

### DIFF
--- a/Assets/css/eict.css
+++ b/Assets/css/eict.css
@@ -103,9 +103,14 @@
 .x-board-modern .carousel-inner {
     height:100%;
 }
-.x-board-modern #carouselExampleIndicators div  div  img {
-    object-fit: fill !important;
-    width: auto;
+.x-board-modern .carousel-inner .carousel-item {
+    height: 100%;
+}
+.x-board-modern .carousel-inner .carousel-item img,
+.x-board-modern #carouselExampleIndicators div div img {
+    width: 100%;
+    height: 100%;
+    object-fit: fill;
 }
 .x-board-modern #banner-section .prayer-time{
     font-size: 30px;

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -227,7 +227,7 @@
 }
 
 .d-masjid-e-usman img.carousel-slide {
-    object-fit: cover;
+    object-fit: fill;
     width: 100%;
     height: 100%;
 }

--- a/Models/DigitalScreen.php
+++ b/Models/DigitalScreen.php
@@ -59,7 +59,10 @@ class DigitalScreen extends DailyShortCode
 
     public function displayDigitalScreen()
     {
-        if ($this->template || get_option('template-chbox')) {
+        $templateEnabled = get_option('template-chbox') === 'template';
+        $hasTemplate = !empty(get_option('dsTemplate'));
+        
+        if ($this->template || ($templateEnabled && $hasTemplate)) {
             return $this->getTemplate();
         }
 
@@ -376,10 +379,14 @@ class DigitalScreen extends DailyShortCode
         return $html;
     }
 
-    private function getPresentationRow()
+    private function getPresentationRow($transitionSpeed = null, $slidesOnly = false)
     {
         $transitionEffect = get_option('transitionEffect');
-        $transitionSpeed = get_option('transitionSpeed');
+        $transitionSpeed = $transitionSpeed ?? get_option('transitionSpeed');
+
+        if ($slidesOnly) {
+            return $this->getPresentationSlides($transitionSpeed);
+        }
 
         $middleRow = $this->isPresentation ? 'middle-row85' : 'middle-row';
 
@@ -394,6 +401,17 @@ class DigitalScreen extends DailyShortCode
         ';
 
         return $html;
+    }
+
+    private function getQuranSlides($transitionSpeed): string
+    {
+        return '<div class="carousel-item active height-100" data-bs-interval="10000">
+            <div class="nextPrayer">
+                <div class="align-middle-next-prayer">
+                    <h4 id="quranVerse" class="' . $this->verticalClass . '"></h4>
+                </div>
+            </div>
+        </div>';
     }
 
     private function getPresentationSlides($transitionSpeed): string
@@ -532,13 +550,18 @@ class DigitalScreen extends DailyShortCode
         }
 
         foreach (range(1, 11) as $item) {
-            $slides[] = get_option('slider' . $item);
-            $slides = array_filter($slides, function($slide) {
-                return filter_var($slide, FILTER_VALIDATE_URL);
-            });
+            $slideUrl = get_option('slider' . $item);
+            if (!empty($slideUrl) && filter_var($slideUrl, FILTER_VALIDATE_URL)) {
+                $slides[] = $slideUrl;
+            }
         }
 
         return $slides;
+    }
+    
+    public function hasSliderImages(): bool
+    {
+        return !empty($this->getSliderUrls());
     }
 
     private function getImageOrMessage($slide): string

--- a/Models/Processors/DigitalScreenProcessor.php
+++ b/Models/Processors/DigitalScreenProcessor.php
@@ -47,10 +47,9 @@ if ( !class_exists('DPTDigitalScreenProcessor')) {
             update_option('nextPrayerSlide', $nextPrayerSlide);
             
             $dsTemplate = sanitize_text_field($this->data['ds-template']);
+            error_log('DEBUG: dsTemplate value before save: ' . $dsTemplate);
             update_option('dsTemplate', $dsTemplate);
-            if (empty($template)) {
-                delete_option('dsTemplate');
-            }
+            error_log('DEBUG: dsTemplate option saved, current value: ' . get_option('dsTemplate'));
 
             $transitionEffect = sanitize_text_field($this->data['transitionEffect']);
             update_option('transitionEffect', $transitionEffect);

--- a/Models/Processors/DigitalScreenProcessor.php
+++ b/Models/Processors/DigitalScreenProcessor.php
@@ -47,9 +47,7 @@ if ( !class_exists('DPTDigitalScreenProcessor')) {
             update_option('nextPrayerSlide', $nextPrayerSlide);
             
             $dsTemplate = sanitize_text_field($this->data['ds-template']);
-            error_log('DEBUG: dsTemplate value before save: ' . $dsTemplate);
             update_option('dsTemplate', $dsTemplate);
-            error_log('DEBUG: dsTemplate option saved, current value: ' . get_option('dsTemplate'));
 
             $transitionEffect = sanitize_text_field($this->data['transitionEffect']);
             update_option('transitionEffect', $transitionEffect);

--- a/Models/Processors/DigitalScreenProcessor.php
+++ b/Models/Processors/DigitalScreenProcessor.php
@@ -28,12 +28,10 @@ if ( !class_exists('DPTDigitalScreenProcessor')) {
             $dsBlinkText = sanitize_text_field($this->data['ds-blink-text']);
             update_option('ds-blink-text', $dsBlinkText);
 
-            $dsAdditionalCss = sanitize_textarea_field($this->data['ds-additional-css'] ?? '');
-            $dsAdditionalCss = preg_replace('/\r\n/', "\n", $dsAdditionalCss);
+            $dsAdditionalCss = trim($this->data['ds-additional-css'] ?? '');
             update_option('ds-additional-css', $dsAdditionalCss);
 
-            $dsFadingMsg = sanitize_textarea_field($this->data['ds-fading-msg'] ?? '');
-            $dsFadingMsg = preg_replace('/\r\n/', "\n", $dsFadingMsg);
+            $dsFadingMsg = trim($this->data['ds-fading-msg'] ?? '');
             update_option('ds-fading-msg', $dsFadingMsg);
 
             $template = sanitize_text_field($this->data['template-chbox']);

--- a/Models/Processors/DigitalScreenProcessor.php
+++ b/Models/Processors/DigitalScreenProcessor.php
@@ -28,10 +28,12 @@ if ( !class_exists('DPTDigitalScreenProcessor')) {
             $dsBlinkText = sanitize_text_field($this->data['ds-blink-text']);
             update_option('ds-blink-text', $dsBlinkText);
 
-            $dsAdditionalCss = sanitize_textarea_field($this->data['ds-additional-css']);
+            $dsAdditionalCss = sanitize_textarea_field($this->data['ds-additional-css'] ?? '');
+            $dsAdditionalCss = preg_replace('/\r\n/', "\n", $dsAdditionalCss);
             update_option('ds-additional-css', $dsAdditionalCss);
 
-            $dsFadingMsg = sanitize_textarea_field($this->data['ds-fading-msg']);
+            $dsFadingMsg = sanitize_textarea_field($this->data['ds-fading-msg'] ?? '');
+            $dsFadingMsg = preg_replace('/\r\n/', "\n", $dsFadingMsg);
             update_option('ds-fading-msg', $dsFadingMsg);
 
             $template = sanitize_text_field($this->data['template-chbox']);

--- a/Models/Processors/DigitalScreenProcessor.php
+++ b/Models/Processors/DigitalScreenProcessor.php
@@ -28,10 +28,10 @@ if ( !class_exists('DPTDigitalScreenProcessor')) {
             $dsBlinkText = sanitize_text_field($this->data['ds-blink-text']);
             update_option('ds-blink-text', $dsBlinkText);
 
-            $dsAdditionalCss = sanitize_text_field($this->data['ds-additional-css']);
+            $dsAdditionalCss = sanitize_textarea_field($this->data['ds-additional-css']);
             update_option('ds-additional-css', $dsAdditionalCss);
 
-            $dsFadingMsg = sanitize_text_field($this->data['ds-fading-msg']);
+            $dsFadingMsg = sanitize_textarea_field($this->data['ds-fading-msg']);
             update_option('ds-fading-msg', $dsFadingMsg);
 
             $template = sanitize_text_field($this->data['template-chbox']);

--- a/Models/design/eict.php
+++ b/Models/design/eict.php
@@ -50,14 +50,14 @@
         $leftClass = 'col-md-12 col-sm-12 col-12';
         $rightClass = '';
         $slides = '';
-        if ( get_option('quran-chbox') || get_option('slider-chbox')) {
+        if ( get_option('quran-chbox') || get_option('slider-chbox') || $this->hasSliderImages()) {
             $leftClass = 'col-md-4 col-sm-4 col-4';
             $rightClass = 'col-md-8 col-sm-8 col-8';
 
             if ( get_option('quran-chbox')) {
                 $slides = $this->getQuranSlides($transitionSpeed);
             } else {
-                $slides = $this->getPresentationRow($transitionSpeed);
+                $slides = $this->getPresentationRow($transitionSpeed, true);
             }
         }
     ?>
@@ -77,7 +77,6 @@
                     $slidesHtml ='
                         <div id="carouselExampleIndicators" class="carousel slide ' . $transitionEffect . ' height-100" data-bs-ride="carousel">
                             <div class="carousel-inner height-100">
-                                <div class="carousel-item active"></div>
                                 ' . $slides . '
                             </div>';
                             $slidesHtml .= '

--- a/Models/design/usman.php
+++ b/Models/design/usman.php
@@ -102,14 +102,14 @@ $html = '';
             $rightClass = '';
             $slides = '';
 
-            if (get_option('quran-chbox') || get_option('slider-chbox')) {
+            if (get_option('quran-chbox') || get_option('slider-chbox') || $this->hasSliderImages()) {
                 $leftClass = 'col-md-4 col-sm-4 col-4';
                 $rightClass = 'col-md-8 col-sm-8 col-8';
 
                 if (get_option('quran-chbox')) {
                     $slides = $this->getQuranSlides($transitionSpeed);
                 } else {
-                    $slides = $this->getPresentationRow($transitionSpeed);
+                    $slides = $this->getPresentationRow($transitionSpeed, true);
                 }
             }
             ?>
@@ -121,7 +121,7 @@ $html = '';
                         </div>
                     </div>
                 </div>
-                <div class="row masjid-name-logo">
+                <div class="row mosque-info-overlay">
                     <div class="col-md-3 logo-section">
                         <?php echo $this->getLogoUrl(); ?>
                     </div>

--- a/Views/DSTemplate.php
+++ b/Views/DSTemplate.php
@@ -42,7 +42,7 @@ if (is_page_template( '../Views/DSTemplate.php' )) {
     <?php //wp_head(); ?>
 
     <style>
-        <?php echo esc_html(get_option("ds-additional-css") )?>
+        <?php echo get_option('ds-additional-css'); ?>
     </style>
     
 </head>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -290,7 +290,7 @@ class DigitalScreenSettings {
             <div class="dpt-section-content">
                 <div class="dpt-template-grid">
                     <?php foreach ($this->templates as $key => $template): ?>
-                    <label class="dpt-template-card <?php echo $template['isSelected'] ? 'selected' : ''; ?>">
+                    <label class="dpt-template-card <?php echo $template['isSelected'] ? 'selected' : ''; ?>" onclick="selectTemplate('<?php echo esc_js($key); ?>', this)">
                         <img src="<?php echo esc_url($template['image']); ?>" alt="<?php echo esc_attr($template['name']); ?>">
                         <div>
                             <input type="radio" name="ds-template" value="<?php echo esc_attr($key); ?>"
@@ -374,6 +374,21 @@ class DigitalScreenSettings {
             header.parentElement.classList.toggle('active');
         }
         
+        function selectTemplate(value, element) {
+            // Set the radio button
+            const radio = element.querySelector('input[type="radio"]');
+            radio.checked = true;
+            
+            // Update visual selection
+            document.querySelectorAll('.dpt-template-card').forEach(function(card) {
+                card.classList.remove('selected');
+            });
+            element.classList.add('selected');
+            
+            // Log for debugging
+            console.log('Selected template:', value);
+        }
+        
         window.updateDisplayMode = function(value) {
             const sliderSection = document.getElementById('dpt-slider-section');
             const quranInput = document.getElementById('quran-chbox-hidden');
@@ -420,28 +435,6 @@ class DigitalScreenSettings {
                 });
                 
                 frame.open();
-            });
-            
-// Template selection - only for enabled radios (skip placeholder)
-            $('.dpt-template-card:not(.dpt-template-placeholder)').on('click', function(e) {
-                e.preventDefault();
-                e.stopPropagation();
-                
-                const radio = $(this).find('input[type="radio"]');
-                radio.prop('checked', true).trigger('change');
-                
-                // Update UI
-                $('.dpt-template-card').removeClass('selected');
-                $(this).addClass('selected');
-                
-                // Debug - check if value is being set
-                console.log('Template selected:', radio.val());
-                console.log('Radio checked:', radio.prop('checked'));
-            });
-            
-            // Debug: Log all form data on submit
-            $('form[name="digitalScreen"]').on('submit', function() {
-                console.log('ds-template value:', $('input[name="ds-template"]:checked').val());
             });
         });
         </script>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -31,7 +31,7 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
 .dpt-ds-field label { font-weight: 600; font-size: 13px; color: #444; }
 .dpt-ds-field input, .dpt-ds-field textarea { padding: 8px; border: 1px solid #ccc; border-radius: 4px; }
 .dpt-ds-field input:focus, .dpt-ds-field textarea:focus { outline: 2px solid #2271b1; border-color: #2271b1; }
-.dpt-ds-field .hint { font-size: 11px; color: #666; font-weight: normal; }
+.dpt-ds-field .hint { font-weight: normal; color: #666; }
 
 .dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
 .dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 10px; cursor: pointer; transition: all 0.2s; }
@@ -93,6 +93,10 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
 .instructions-box h3 { margin-top: 0; color: #2271b1; font-size: 16px; }
 .instructions-box code { background: #fff; padding: 2px 5px; border-radius: 3px; font-size: 12px; }
 .instructions-box li { margin-bottom: 8px; font-size: 13px; }
+
+.dpt-exclusive-group { display: flex; gap: 20px; margin-bottom: 15px; flex-wrap: wrap; }
+.dpt-exclusive-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+.dpt-exclusive-group input { width: auto; }
 </style>
 
 <h3>Masjid/Mobile Screen Settings</h3>
@@ -101,45 +105,24 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
     <?php echo wp_nonce_field( 'digitalScreen'); ?>
     
     <div id="dpt-ds-accordions">
-        <!-- Template Selection -->
-        <div class="dpt-ds-accordion active">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection</div>
-            <div class="accordion-content">
-                <div class="dpt-template-grid">
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
-                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
-                    </label>
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
-                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
-                    </label>
-                    <label class="dpt-template-card" style="opacity: 0.6;">
-                        <div style="padding: 40px 10px;">Coming Soon</div>
-                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
-                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
-                    </label>
-                </div>
-            </div>
-        </div>
-
+        
         <!-- General Settings -->
-        <div class="dpt-ds-accordion">
+        <div class="dpt-ds-accordion active">
             <div class="accordion-header" onclick="toggleDsAccordion(this)">⚙️ General Settings</div>
             <div class="accordion-content">
-                <div class="dpt-ds-row">
-                    <div class="dpt-ds-field">
-                        <label class="dpt-ds-checkbox">
-                            <input type="checkbox" name="template-chbox" value="template" <?php if(get_option("template-chbox") === 'template'){ echo 'checked'; } ?>>
-                            Show Template Header
-                        </label>
-                    </div>
-                    <div class="dpt-ds-field">
-                        <label class="dpt-ds-checkbox">
-                            <input type="checkbox" name="quran-chbox" value="displayQuran" <?php if(get_option("quran-chbox") === 'displayQuran'){ echo 'checked'; } ?>>
-                            Display Quran Verse
-                        </label>
-                    </div>
+                <div class="dpt-exclusive-group">
+                    <label>
+                        <input type="radio" name="displayMode" value="none" <?php echo (get_option("quran-chbox") !== 'displayQuran' && get_option("slider-chbox") !== 'slider') ? 'checked' : ''; ?>>
+                        None
+                    </label>
+                    <label>
+                        <input type="radio" name="displayMode" value="quran" <?php echo (get_option("quran-chbox") === 'displayQuran') ? 'checked' : ''; ?>>
+                        Display Quran Verse
+                    </label>
+                    <label>
+                        <input type="radio" name="displayMode" value="slider" <?php echo (get_option("slider-chbox") === 'slider') ? 'checked' : ''; ?>>
+                        Activate Slider
+                    </label>
                 </div>
                 <div class="dpt-ds-field" style="margin-top: 15px;">
                     <label>Fading Messages <span class="hint">(separated by full stop)</span></label>
@@ -173,17 +156,11 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
             </div>
         </div>
 
-        <!-- Slider Settings -->
+        <!-- Slider Settings + Image Sliders (merged) -->
         <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider Settings</div>
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider / Quran Settings</div>
             <div class="accordion-content">
-                <div class="dpt-ds-field" style="margin-bottom: 15px;">
-                    <label class="dpt-ds-checkbox">
-                        <input type="checkbox" name="slider-chbox" value="slider" <?php if(get_option("slider-chbox") === 'slider'){ echo 'checked'; } ?>>
-                        Activate Slider
-                    </label>
-                </div>
-                <div class="dpt-ds-row">
+                <div class="dpt-ds-row" style="margin-bottom: 20px;">
                     <div class="dpt-ds-field">
                         <label>Re-display Next Prayer After # Slides</label>
                         <input type="number" name="nextPrayerSlide" min="0" value="<?php echo esc_html(get_option("nextPrayerSlide")); ?>">
@@ -200,13 +177,9 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
                         <input type="number" name="transitionSpeed" min="0" placeholder="5" value="<?php echo esc_html(get_option("transitionSpeed") / 1000); ?>">
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <!-- Sliders -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">📷 Image Sliders <span class="hint">(click to expand)</span></div>
-            <div class="accordion-content">
+                
+                <hr style="margin: 20px 0;">
+                
                 <p style="margin-bottom: 15px; color: #666;">Click <strong>"🖼️ Select from Media"</strong> to choose images from your gallery. Maximum 7 sliders.</p>
                 <div class="dpt-sliders-container">
                     <?php for ($i = 1; $i <= 11; $i++): ?>
@@ -264,6 +237,29 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
                 </div>
             </div>
         </div>
+
+        <!-- Template Selection (at bottom, optional) -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
+            <div class="accordion-content">
+                <div class="dpt-template-grid">
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
+                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
+                    </label>
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
+                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
+                    </label>
+                    <label class="dpt-template-card" style="opacity: 0.6;">
+                        <div style="padding: 40px 10px;">Coming Soon</div>
+                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
+                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
+                    </label>
+                </div>
+            </div>
+        </div>
+
     </div>
 
     <div style="margin-top: 20px;">
@@ -278,6 +274,21 @@ function toggleDsAccordion(header) {
 }
 
 jQuery(document).ready(function($) {
+    // Handle exclusive radio buttons
+    $('input[name="displayMode"]').on('change', function() {
+        var value = $(this).val();
+        if (value === 'quran') {
+            $('input[name="quran-chbox"]').val('displayQuran');
+            $('input[name="slider-chbox"]').val('');
+        } else if (value === 'slider') {
+            $('input[name="slider-chbox"]').val('slider');
+            $('input[name="quran-chbox"]').val('');
+        } else {
+            $('input[name="quran-chbox"]').val('');
+            $('input[name="slider-chbox"]').val('');
+        }
+    });
+    
     // Add Another Slider button
     $('#dpt-add-slider').on('click', function() {
         var $hidden = $('.dpt-slider-section.dpt-slider-hidden').first();

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -66,8 +66,7 @@ class DigitalScreenSettings {
             .dpt-slider-row { display: flex; gap: 20px; align-items: flex-start; }
             .dpt-slider-fields { flex: 1; }
             .dpt-slider-preview { 
-                width: 120px; 
-                height: 90px; 
+                width: 15%; 
                 display: flex; 
                 align-items: center; 
                 justify-content: center;
@@ -100,7 +99,11 @@ class DigitalScreenSettings {
             .dpt-image-preview { max-height: 28px; margin-left: 8px; }
             
             .dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
-            .dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 12px; cursor: pointer; }
+            @media (max-width: 768px) { .dpt-template-grid { grid-template-columns: 1fr; } }
+            .dpt-template-card { 
+                border: 2px solid #ddd; border-radius: 8px; padding: 12px; cursor: pointer;
+                display: flex; flex-direction: column; justify-content: flex-end;
+            }
             .dpt-template-card:hover { border-color: #2271b1; }
             .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -63,6 +63,20 @@ class DigitalScreenSettings {
                 background: #f9f9f9;
             }
             .dpt-slider-card h4 { margin: 0 0 12px 0; color: #2271b1; }
+            .dpt-slider-row { display: flex; gap: 15px; align-items: center; }
+            .dpt-slider-fields { flex: 1; }
+            .dpt-slider-preview { 
+                width: 80px; 
+                height: 60px; 
+                display: flex; 
+                align-items: center; 
+                justify-content: center;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                background: #f9f9f9;
+                flex-shrink: 0;
+            }
+            .dpt-slider-preview img { max-width: 100%; max-height: 100%; }
             .dpt-slider-input-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
             .dpt-slider-input-row input { flex: 1; }
             .dpt-slider-url-row { display: flex; gap: 15px; margin-top: 8px; }
@@ -224,16 +238,22 @@ class DigitalScreenSettings {
                 <?php for ($i = 1; $i <= self::TOTAL_SLIDER_FIELDS; $i++): ?>
                 <div class="dpt-slider-card <?php echo $i > $displayCount ? 'hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
                     <h4>Slider #<?php echo $i; ?></h4>
-                    <div class="dpt-slider-input-row">
-                        <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
-                        <input type="text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" 
-                            value="<?php echo esc_attr(get_option("slider$i") ?? ''); ?>">
-                        <?php echo $this->displayImage(get_option("slider$i")); ?>
-                    </div>
-                    <div class="dpt-slider-input-row">
-                        <span class="dpt-slider-url-label">Optional link:</span>
-                        <input type="text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" 
-                            value="<?php echo esc_attr(get_option("slider{$i}Url") ?? ''); ?>">
+                    <div class="dpt-slider-row">
+                        <div class="dpt-slider-fields">
+                            <div class="dpt-slider-input-row">
+                                <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
+                                <input type="text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" 
+                                    value="<?php echo esc_attr(get_option("slider$i") ?? ''); ?>">
+                            </div>
+                            <div class="dpt-slider-input-row">
+                                <span class="dpt-slider-url-label">Optional link:</span>
+                                <input type="text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" 
+                                    value="<?php echo esc_attr(get_option("slider{$i}Url") ?? ''); ?>">
+                            </div>
+                        </div>
+                        <div class="dpt-slider-preview">
+                            <?php echo $this->displayImage(get_option("slider$i")); ?>
+                        </div>
                     </div>
                 </div>
                 <?php endfor; ?>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -425,10 +425,23 @@ class DigitalScreenSettings {
 // Template selection - only for enabled radios (skip placeholder)
             $('.dpt-template-card:not(.dpt-template-placeholder)').on('click', function(e) {
                 e.preventDefault();
+                e.stopPropagation();
+                
                 const radio = $(this).find('input[type="radio"]');
                 radio.prop('checked', true).trigger('change');
+                
+                // Update UI
                 $('.dpt-template-card').removeClass('selected');
                 $(this).addClass('selected');
+                
+                // Debug - check if value is being set
+                console.log('Template selected:', radio.val());
+                console.log('Radio checked:', radio.prop('checked'));
+            });
+            
+            // Debug: Log all form data on submit
+            $('form[name="digitalScreen"]').on('submit', function() {
+                console.log('ds-template value:', $('input[name="ds-template"]:checked').val());
             });
         });
         </script>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -99,17 +99,17 @@ class DigitalScreenSettings {
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
 
             .dpt-form-row-wide { margin-top: 20px; }
-            .dpt-image-preview { max-height: 30px; margin-left: 10px; }
+            .dpt-image-preview { max-height: 30px; margin-left: 10px; transition: all 0.3s ease; }
             .dpt-image-preview:hover { 
                 position: fixed; 
-                top: 50%; left: 50%; 
-                transform: translate(-50%, -50%); 
-                max-height: 80vh; 
-                max-width: 80vw; 
+                bottom: 20px; right: 20px; 
+                max-height: 50vh; 
+                max-width: 50vw; 
                 z-index: 9999; 
                 background: #fff; 
                 padding: 10px;
                 box-shadow: 0 0 20px rgba(0,0,0,0.5);
+                border-radius: 8px;
             }
         </style>
         <?php

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -395,7 +395,6 @@ class DigitalScreenSettings {
             } else if (checkedValueAlt === 'slider') {
                 $('#slider-chbox-hidden').val('slider');
             }
-            }
             
             // Add slider button
             $('#dpt-add-slider').on('click', function() {

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -361,6 +361,16 @@ class DigitalScreenSettings {
                 $('#dpt-template-section').addClass('hidden');
             }
             
+            // Sync hidden inputs with checked radio on page load
+            const checkedValue = $('input[name="displayMode"]:checked').val();
+            if (checkedValue === 'quran') {
+                $('#quran-chbox-hidden').val('displayQuran');
+            } else if (checkedValue === 'slider') {
+                $('#slider-chbox-hidden').val('slider');
+            } else if (checkedValue === 'template') {
+                $('#template-chbox-hidden').val('template');
+            }
+            
             // Add slider button
             $('#dpt-add-slider').on('click', function() {
                 const hidden = $('.dpt-slider-card.hidden').first();

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -131,12 +131,12 @@ class DigitalScreenSettings {
                     </label>
                     <span class="dpt-separator">|</span>
                     <label>
-                        <input type="radio" name="displayMode" value="quran" 
+                        <input type="radio" name="displayModeAlt" value="quran" 
                             <?php echo get_option('quran-chbox') === 'displayQuran' ? 'checked' : ''; ?>>
                         Display Quran Verse
                     </label>
                     <label>
-                        <input type="radio" name="displayMode" value="slider" 
+                        <input type="radio" name="displayModeAlt" value="slider" 
                             <?php echo $sliderActive ? 'checked' : ''; ?>>
                         Activate Slider
                     </label>
@@ -336,8 +336,28 @@ class DigitalScreenSettings {
         }
         
         jQuery(document).ready(function($) {
-            // Display mode selection
+            // Display mode selection - group 1 (default/template)
             $('input[name="displayMode"]').on('change', function() {
+                const value = $(this).val();
+                const sliderSection = $('#dpt-slider-section');
+                const templateSection = $('#dpt-template-section');
+                const sliderInput = $('#slider-chbox-hidden');
+                const templateInput = $('#template-chbox-hidden');
+                
+                if (value === 'template') {
+                    sliderInput.val('');
+                    templateInput.val('template');
+                    sliderSection.removeClass('active').addClass('hidden');
+                    templateSection.removeClass('hidden').addClass('active');
+                } else if (value === 'default') {
+                    templateInput.val('');
+                    sliderSection.removeClass('active').addClass('hidden');
+                    templateSection.removeClass('active').addClass('hidden');
+                }
+            });
+            
+            // Display mode selection - group 2 (quran/slider)
+            $('input[name="displayModeAlt"]').on('change', function() {
                 const value = $(this).val();
                 const sliderSection = $('#dpt-slider-section');
                 const templateSection = $('#dpt-template-section');
@@ -356,19 +376,6 @@ class DigitalScreenSettings {
                     templateInput.val('');
                     quranInput.val('displayQuran');
                     sliderSection.removeClass('active').addClass('hidden');
-                    templateSection.removeClass('active').addClass('hidden');
-                } else if (value === 'template') {
-                    sliderInput.val('');
-                    quranInput.val('');
-                    templateInput.val('template');
-                    sliderSection.removeClass('active').addClass('hidden');
-                    templateSection.removeClass('hidden').addClass('active');
-                } else if (value === 'default') {
-                    sliderInput.val('');
-                    templateInput.val('');
-                    quranInput.val('');
-                    sliderSection.removeClass('active').addClass('hidden');
-                    templateSection.removeClass('active').addClass('hidden');
                 }
             });
             
@@ -379,12 +386,15 @@ class DigitalScreenSettings {
             
             // Sync hidden inputs with checked radio on page load
             const checkedValue = $('input[name="displayMode"]:checked').val();
-            if (checkedValue === 'quran') {
-                $('#quran-chbox-hidden').val('displayQuran');
-            } else if (checkedValue === 'slider') {
-                $('#slider-chbox-hidden').val('slider');
-            } else if (checkedValue === 'template') {
+            const checkedValueAlt = $('input[name="displayModeAlt"]:checked').val();
+            
+            if (checkedValue === 'template') {
                 $('#template-chbox-hidden').val('template');
+            } else if (checkedValueAlt === 'quran') {
+                $('#quran-chbox-hidden').val('displayQuran');
+            } else if (checkedValueAlt === 'slider') {
+                $('#slider-chbox-hidden').val('slider');
+            }
             }
             
             // Add slider button

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -99,7 +99,7 @@ class DigitalScreenSettings {
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
 
             .dpt-form-row-wide { margin-top: 20px; }
-            .dpt-image-preview { max-height: 30px; margin-left: 10px; }
+            .dpt-image-preview { max-height: 30px; margin-left: 10px; cursor: pointer; }
             #dpt-image-enlarged {
                 display: none;
                 position: fixed;
@@ -110,13 +110,15 @@ class DigitalScreenSettings {
                 border-radius: 8px;
                 max-width: 45vw;
                 max-height: 45vh;
-                transition: all 0.3s ease-out;
-                opacity: 0;
-                transform: scale(0.8);
             }
             #dpt-image-enlarged.show {
                 display: block;
-                opacity: 1;
+                animation: dptZoomIn 0.3s ease-out;
+            }
+            @keyframes dptZoomIn {
+                from { opacity: 0; transform: scale(0.8); }
+                to { opacity: 1; transform: scale(1); }
+            }
                 transform: scale(1);
             }
         </style>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -129,6 +129,11 @@ class DigitalScreenSettings {
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }
             .dpt-template-card.dpt-template-placeholder { opacity: 0.8; cursor: pointer; border-style: dashed; }
             .dpt-template-card.dpt-template-placeholder:hover { border-color: #2271b1; background: #f5f5f5; }
+            .dpt-placeholder-img { 
+                height: 100px; background: #e0e0e0; border-radius: 4px; margin-bottom: 8px;
+                display: flex; align-items: center; justify-content: center;
+                color: #888; font-size: 13px; border: 2px dashed #bbb;
+            }
             
             .dpt-instructions { background: #f0f0f1; padding: 15px; border-radius: 8px; }
             .dpt-instructions h3 { margin: 0 0 12px 0; color: #2271b1; }
@@ -293,12 +298,12 @@ class DigitalScreenSettings {
                     </label>
                     <?php endforeach; ?>
                     <label class="dpt-template-card dpt-template-placeholder">
-                        <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEzMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEzMCIgZmlsbD0iI2YzZjRmNiIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LXNpemU9IjE0IiBmaWxsPSIjOTk5IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSI+TGV0J3MgZGlzc3Vzc+PC90ZXh0Pjx0ZXh0IHg9IjUwJSIgeT0iNjAlIiBmb250LXNpemU9IjEyIiBmaWxsPSIjNjY2IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj7CoCBEcm9wIHRoZSBpbWFnZSBobZXJlPC90ZXh0Pjwvc3ZnPg==" alt="Add your template">
+                        <div class="dpt-placeholder-img">Add your template here</div>
                         <div>
                             <input type="radio" name="ds-template" value="custom" disabled>
                             <strong>Add your template here</strong>
                         </div>
-                        <small><a href="mailto:mmrs151@gmail.com">Let's discuss</a></small>
+                        <small><a href="mailto:mmrs151@gmail.com?subject=Custom Template Design">Let's discuss</a></small>
                     </label>
                 </div>
             </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -5,7 +5,70 @@ function displayImage($slide){
     }
     return '';
 }
+$maxSliders = 7;
+$existingSliders = 0;
+for ($i = 1; $i <= 11; $i++) {
+    if (!empty(get_option("slider$i"))) {
+        $existingSliders = max($existingSliders, $i);
+    }
+}
+$displayCount = max(1, min($existingSliders, $maxSliders));
 ?>
+<style>
+.dpt-slider-row { display: flex; align-items: center; gap: 8px; }
+.dpt-slider-row input[type="text"] { flex: 1; }
+.dpt-media-btn { 
+    padding: 6px 10px; cursor: pointer; border: 1px solid #ccc; 
+    background: #f0f0f0; border-radius: 4px; font-size: 16px; 
+}
+.dpt-media-btn:hover { background: #e0e0e0; }
+.dpt-add-slider-btn {
+    margin-top: 10px; padding: 8px 16px; cursor: pointer;
+    background: #2271b1; color: #fff; border: none; border-radius: 4px;
+}
+.dpt-add-slider-btn:hover { background: #1d5a8a; }
+.dpt-slider-hidden { display: none; }
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+    var frame;
+    $('.dpt-media-btn').on('click', function(e) {
+        e.preventDefault();
+        var $button = $(this);
+        var $input = $button.closest('.dpt-slider-row').find('input[name="slider[]"]');
+        
+        if (frame) {
+            frame.open();
+            return;
+        }
+        
+        frame = wp.media({
+            title: 'Select Image for Slider',
+            button: { text: 'Use this image' },
+            multiple: false
+        });
+        
+        frame.on('select', function() {
+            var attachment = frame.state().get('selection').first().toJSON();
+            $input.val(attachment.url).trigger('change');
+        });
+        
+        frame.open();
+    });
+    
+    $('.dpt-add-slider-btn').on('click', function() {
+        var currentVisible = $('.ds-slides:visible').length;
+        if (currentVisible < 7) {
+            $('.ds-slides').eq(currentVisible).show();
+            if ($('.ds-slides:visible').length >= 7) {
+                $(this).hide();
+            }
+        }
+    });
+});
+</script>
+
 <h3>Masjid/Mobile screen settings</h3>
 <div class="container-fluid">
     <form class="form-group" name="digitalScreen" method="post">
@@ -94,92 +157,24 @@ function displayImage($slide){
                         <td><input type="number" min="0" class="slider-text" name="transitionSpeed" placeholder="5" value=<?php echo esc_html(get_option("transitionSpeed")/1000 ) ?>> seconds </td>
                     </tr>
 
-                    <tr class="ds-slides">
-                        <td>Slider #1</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider1" size="30" value="<?php echo esc_html(stripslashes(get_option("slider1")) )?>">
-                        <?php echo displayImage(get_option("slider1")); ?>
+                    <?php for ($i = 1; $i <= 11; $i++): ?>
+                    <tr class="ds-slides<?php echo ($i > $displayCount) ? ' dpt-slider-hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
+                        <td>Slider #<?php echo $i; ?></td>
+                        <td>
+                            <div class="dpt-slider-row">
+                                <button type="button" class="dpt-media-btn" title="Select from Media Gallery">🖼️</button>
+                                <input type="text" class="slider-text" placeholder="Any message or image url" name="slider<?php echo $i; ?>" size="30" value="<?php echo esc_html(stripslashes(get_option("slider$i")) )?>">
+                            </div>
+                            <?php echo displayImage(get_option("slider$i")); ?>
                             <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider1Url" size="30" value=<?php echo esc_html(get_option("slider1Url") )?>>
+                            <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider<?php echo $i; ?>Url" size="30" value=<?php echo esc_html(get_option("slider{$i}Url") )?>>
                         </td>
                     </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #2</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider2" size="30" value="<?php echo esc_html(stripslashes(get_option("slider2")) )?>">
-                        <?php echo displayImage(get_option("slider2")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider2Url" size="30" value=<?php echo esc_html(get_option("slider2Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #3</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider3" size="30" value="<?php echo esc_html(stripslashes(get_option("slider3")) )?>">
-                            <?php echo displayImage(get_option("slider3")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider3Url" size="30" value=<?php echo esc_html(get_option("slider3Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #4</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider4" size="30" value="<?php echo esc_html(stripslashes(get_option("slider4")) )?>">
-                            <?php echo displayImage(get_option("slider4")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider4Url" size="30" value=<?php echo esc_html(get_option("slider4Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #5</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider5" size="30" value="<?php echo esc_html(stripslashes(get_option("slider5")) )?>">
-                            <?php echo displayImage(get_option("slider5")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider5Url" size="30" value=<?php echo esc_html(get_option("slider5Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #6</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider6" size="30" value="<?php echo esc_html(stripslashes(get_option("slider6")) )?>">
-                            <?php echo displayImage(get_option("slider6")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider6Url" size="30" value=<?php echo esc_html(get_option("slider6Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #7</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider7" size="30" value="<?php echo esc_html(stripslashes(get_option("slider7")) )?>">
-                            <?php echo displayImage(get_option("slider7")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider7Url" size="30" value=<?php echo esc_html(get_option("slider7Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #8</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider8" size="30" value="<?php echo esc_html(stripslashes(get_option("slider8")) )?>">
-                            <?php echo displayImage(get_option("slider8")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider8Url" size="30" value=<?php echo esc_html(get_option("slider8Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #9</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider9" size="30" value="<?php echo esc_html(stripslashes(get_option("slider9")) )?>">
-                            <?php echo displayImage(get_option("slider9")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider9Url" size="30" value=<?php echo esc_html(get_option("slider9Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #10</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider10" size="30" value="<?php echo esc_html(stripslashes(get_option("slider10")) )?>">
-                            <?php echo displayImage(get_option("slider10")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider10Url" size="30" value=<?php echo esc_html(get_option("slider10Url") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Slider #11</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="slider11" size="30" value="<?php echo esc_html(stripslashes(get_option("slider11")) )?>">
-                            <?php echo displayImage(get_option("slider11")); ?>
-                            <br/>
-                                <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider11Url" size="30" value=<?php echo esc_html(get_option("slider11Url") )?>>
+                    <?php endfor; ?>
+                    
+                    <tr>
+                        <td colspan="2">
+                            <button type="button" class="dpt-add-slider-btn"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
                         </td>
                     </tr>
                     <tr>
@@ -205,4 +200,3 @@ function displayImage($slide){
     </div>
     </form>
 </div>
-

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -1,215 +1,295 @@
 <?php
-function displayImage($slide){
-    if (filter_var($slide, FILTER_VALIDATE_URL)) {
-        return  '<img src="' . esc_html($slide ) . '" style="max-height: 30px;" class="grow">';
-    }
-    return '';
-}
-$maxSliders = 7;
-$existingSliders = 0;
-for ($i = 1; $i <= 11; $i++) {
-    if (!empty(get_option("slider$i"))) {
-        $existingSliders = max($existingSliders, $i);
-    }
-}
-$displayCount = max(1, min($existingSliders, $maxSliders));
-$isSliderActive = get_option("slider-chbox") === 'slider';
-?>
-<style>
-.dpt-ds-accordion { margin-bottom: 10px; }
-.dpt-ds-accordion .accordion-header { 
-    background: #2271b1; color: #fff; padding: 12px 15px; cursor: pointer; 
-    border-radius: 4px; display: flex; justify-content: space-between; align-items: center;
-}
-.dpt-ds-accordion .accordion-header:hover { background: #1d5a8a; }
-.dpt-ds-accordion .accordion-header:after { content: '▼'; font-size: 10px; transition: transform 0.3s; }
-.dpt-ds-accordion.active .accordion-header:after { transform: rotate(180deg); }
-.dpt-ds-accordion .accordion-content { display: none; padding: 15px; border: 1px solid #ddd; border-top: none; }
-.dpt-ds-accordion.active .accordion-content { display: block; }
-.dpt-ds-accordion.dpt-hidden { display: none; }
+/**
+ * Digital Screen Settings Admin Page
+ * 
+ * Handles configuration for digital screen display options including:
+ * - Display mode (Quran verse or Slider)
+ * - Messages (scrolling, blink text)
+ * - Slider images with media gallery
+ * - Template selection
+ * - Advanced CSS
+ */
 
-.dpt-ds-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 15px; }
-.dpt-ds-field { display: flex; flex-direction: column; gap: 5px; }
-.dpt-ds-field label { font-weight: 600; font-size: 13px; color: #444; }
-.dpt-ds-field input, .dpt-ds-field textarea { padding: 8px; border: 1px solid #ccc; border-radius: 4px; }
-.dpt-ds-field input:focus, .dpt-ds-field textarea:focus { outline: 2px solid #2271b1; border-color: #2271b1; }
-.dpt-ds-field .hint { font-weight: normal; color: #666; }
-
-.dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
-.dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 10px; cursor: pointer; transition: all 0.2s; }
-.dpt-template-card:hover { border-color: #2271b1; }
-.dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
-.dpt-template-card img { max-width: 100%; border-radius: 4px; }
-.dpt-template-card input { margin-top: 8px; }
-
-.dpt-slider-section {
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
-    background: #f9f9f9;
-}
-.dpt-slider-section h4 {
-    margin: 0 0 10px 0;
-    color: #2271b1;
-    font-weight: 600;
-}
-.dpt-slider-input-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-}
-.dpt-slider-input-group input[type="text"] {
-    flex: 1;
-}
-.dpt-slider-input-group img {
-    max-height: 30px;
-    margin-left: 10px;
-    vertical-align: middle;
-}
-.dpt-media-btn { 
-    padding: 8px 12px; cursor: pointer; border: 1px solid #ccc; 
-    background: #fff; border-radius: 4px; font-size: 14px;
-    white-space: nowrap;
-}
-.dpt-media-btn:hover { background: #e0e0e0; border-color: #2271b1; }
-.dpt-add-slider-btn {
-    display: inline-block; padding: 10px 20px; cursor: pointer;
-    background: #2271b1; color: #fff; border: none; border-radius: 4px;
-    font-size: 14px; margin-top: 10px;
-}
-.dpt-add-slider-btn:hover { background: #1d5a8a; }
-.dpt-add-slider-btn:disabled { background: #ccc; cursor: not-allowed; }
-.dpt-slider-hidden { display: none; }
-.dpt-sliders-container { margin-top: 20px; }
-
-.dpt-ds-checkbox { display: flex; align-items: center; gap: 8px; }
-.dpt-ds-checkbox input { width: auto; }
-.dpt-ds-checkbox label { font-weight: normal; }
-
-.dpt-ds-row { display: flex; gap: 20px; flex-wrap: wrap; }
-.dpt-ds-row .dpt-ds-field { flex: 1; min-width: 200px; }
-
-.instructions-box { background: #f0f0f1; padding: 15px; border-radius: 8px; }
-.instructions-box h3 { margin-top: 0; color: #2271b1; font-size: 16px; }
-.instructions-box code { background: #fff; padding: 2px 5px; border-radius: 3px; font-size: 12px; }
-.instructions-box li { margin-bottom: 8px; font-size: 13px; }
-
-.dpt-exclusive-group { display: flex; gap: 20px; margin-bottom: 15px; flex-wrap: wrap; }
-.dpt-exclusive-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
-.dpt-exclusive-group input { width: auto; }
-</style>
-
-<h3>Masjid/Mobile Screen Settings</h3>
-<div class="container-fluid">
-    <form class="form-group" name="digitalScreen" method="post">
-    <?php echo wp_nonce_field( 'digitalScreen'); ?>
+class DigitalScreenSettings {
     
-    <div id="dpt-ds-accordions">
+    const MAX_SLIDERS = 7;
+    const TOTAL_SLIDER_FIELDS = 11;
+    
+    private array $templates = [];
+    private array $displayOptions = [];
+    private array $sliderSettings = [];
+    
+    public function __construct() {
+        $this->loadSettings();
+    }
+    
+    private function loadSettings(): void {
+        $this->templates = [
+            'eict' => [
+                'name' => 'Edgware ICT',
+                'image' => plugins_url('../../Assets/images/EICT.png', __FILE__),
+                'value' => get_option('dsTemplate')
+            ],
+            'usman' => [
+                'name' => 'Masjid-E-Usman',
+                'image' => plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__),
+                'value' => get_option('dsTemplate')
+            ]
+        ];
         
-        <!-- General Settings + Messages (merged, top, expanded) -->
-        <div class="dpt-ds-accordion active">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">⚙️ General Settings</div>
-            <div class="accordion-content">
-                <div class="dpt-exclusive-group">
+        $this->displayOptions = [
+            'quran' => get_option('quran-chbox') === 'displayQuran',
+            'slider' => get_option('slider-chbox') === 'slider'
+        ];
+        
+        $this->sliderSettings = $this->loadSliderSettings();
+    }
+    
+    private function loadSliderSettings(): array {
+        $count = 0;
+        for ($i = 1; $i <= self::TOTAL_SLIDER_FIELDS; $i++) {
+            if (!empty(get_option("slider$i"))) {
+                $count = max($count, $i);
+            }
+        }
+        
+        return [
+            'displayCount' => max(1, min($count, self::MAX_SLIDERS)),
+            'isActive' => $this->displayOptions['slider'],
+            'maxSliders' => self::MAX_SLIDERS
+        ];
+    }
+    
+    public function render(): void {
+        $this->renderStyles();
+        $this->renderFormOpen();
+        $this->renderGeneralSettings();
+        $this->renderSliderSettings();
+        $this->renderTemplateSettings();
+        $this->renderAdvancedSettings();
+        $this->renderInstructions();
+        $this->renderFormClose();
+        $this->renderScripts();
+    }
+    
+    private function renderStyles(): void {
+        ?>
+        <style>
+            .dpt-settings-wrapper { max-width: 1200px; margin: 0 auto; }
+            .dpt-section { margin-bottom: 12px; border-radius: 6px; overflow: hidden; }
+            .dpt-section-header { 
+                background: #2271b1; color: #fff; padding: 14px 18px; cursor: pointer; 
+                display: flex; justify-content: space-between; align-items: center;
+                font-weight: 600; transition: background 0.2s;
+            }
+            .dpt-section-header:hover { background: #1d5a8a; }
+            .dpt-section-header::after { content: '▼'; font-size: 11px; transition: transform 0.3s; }
+            .dpt-section.active .dpt-section-header::after { transform: rotate(180deg); }
+            .dpt-section-content { display: none; padding: 20px; border: 1px solid #ddd; border-top: none; }
+            .dpt-section.active .dpt-section-content { display: block; }
+            .dpt-section.hidden { display: none; }
+            
+            .dpt-form-row { display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 15px; }
+            .dpt-form-group { flex: 1; min-width: 200px; }
+            .dpt-form-group label { display: block; font-weight: 600; margin-bottom: 6px; color: #444; }
+            .dpt-form-group input, .dpt-form-group textarea { 
+                width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;
+            }
+            .dpt-form-group input:focus, .dpt-form-group textarea:focus { 
+                outline: 2px solid #2271b1; border-color: #2271b1; 
+            }
+            .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
+            
+            .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; }
+            .dpt-option-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+            .dpt-option-group input[type="radio"], .dpt-option-group input[type="checkbox"] { width: auto; }
+            
+            .dpt-slider-card {
+                border: 1px solid #ddd; border-radius: 8px; padding: 15px; margin-bottom: 12px;
+                background: #f9f9f9;
+            }
+            .dpt-slider-card h4 { margin: 0 0 12px 0; color: #2271b1; }
+            .dpt-slider-input-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+            .dpt-slider-input-row input { flex: 1; }
+            .dpt-media-btn { 
+                padding: 8px 14px; cursor: pointer; border: 1px solid #ccc; 
+                background: #fff; border-radius: 4px; white-space: nowrap;
+            }
+            .dpt-media-btn:hover { background: #e0e0e0; border-color: #2271b1; }
+            .dpt-add-btn { 
+                display: inline-block; padding: 10px 20px; cursor: pointer;
+                background: #2271b1; color: #fff; border: none; border-radius: 4px;
+            }
+            .dpt-add-btn:hover { background: #1d5a8a; }
+            
+            .dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
+            .dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 12px; cursor: pointer; }
+            .dpt-template-card:hover { border-color: #2271b1; }
+            .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
+            .dpt-template-card img { max-width: 100%; border-radius: 4px; }
+            
+            .dpt-instructions { background: #f0f0f1; padding: 15px; border-radius: 8px; }
+            .dpt-instructions h3 { margin: 0 0 12px 0; color: #2271b1; }
+            .dpt-instructions code { background: #fff; padding: 2px 5px; border-radius: 3px; }
+            .dpt-instructions li { margin-bottom: 6px; }
+            .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
+        </style>
+        <?php
+    }
+    
+    private function renderFormOpen(): void {
+        ?>
+        <h3>Masjid/Mobile Screen Settings</h3>
+        <div class="dpt-settings-wrapper">
+            <form class="form-group" name="digitalScreen" method="post">
+            <?php echo wp_nonce_field('digitalScreen'); ?>
+            <div id="dpt-sections">
+        <?php
+    }
+    
+    private function renderGeneralSettings(): void {
+        $isActive = $this->sliderSettings['isActive'];
+        ?>
+        <div class="dpt-section active">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">⚙️ General Settings</div>
+            <div class="dpt-section-content">
+                <div class="dpt-option-group">
                     <label>
-                        <input type="radio" name="displayMode" value="quran" <?php echo (get_option("quran-chbox") === 'displayQuran') ? 'checked' : ''; ?> onchange="updateDisplayMode(this.value)">
+                        <input type="radio" name="displayMode" value="quran" 
+                            <?php checked($this->displayOptions['quran']); ?> 
+                            onchange="updateDisplayMode(this.value)">
                         Display Quran Verse
                     </label>
                     <label>
-                        <input type="radio" name="displayMode" value="slider" <?php echo (get_option("slider-chbox") === 'slider') ? 'checked' : ''; ?> onchange="updateDisplayMode(this.value)">
+                        <input type="radio" name="displayMode" value="slider" 
+                            <?php checked($this->displayOptions['slider']); ?> 
+                            onchange="updateDisplayMode(this.value)">
                         Activate Slider
                     </label>
                 </div>
-                <!-- Hidden inputs to store actual option values -->
-                <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" value="<?php echo esc_attr(get_option("quran-chbox")); ?>">
-                <input type="hidden" name="slider-chbox" id="slider-chbox-hidden" value="<?php echo esc_attr(get_option("slider-chbox")); ?>">
-                <div class="dpt-ds-field" style="margin-top: 15px;">
-                    <label>Fading Messages <span class="hint">(separated by full stop)</span></label>
-                    <textarea name="ds-fading-msg" rows="3"><?php echo esc_html(stripslashes(get_option("ds-fading-msg")) )?></textarea>
+                <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" 
+                    value="<?php echo esc_attr(get_option('quran-chbox')); ?>">
+                <input type="hidden" name="slider-chbox" id="slider-chbox-hidden" 
+                    value="<?php echo esc_attr(get_option('slider-chbox')); ?>">
+                
+                <div class="dpt-form-row">
+                    <div class="dpt-form-group" style="flex: 2;">
+                        <label>Fading Messages <span class="dpt-hint">(separated by full stop)</span></label>
+                        <textarea name="ds-fading-msg" rows="3"><?php echo esc_textarea(get_option('ds-fading-msg') ?? ''); ?></textarea>
+                    </div>
+                    <div class="dpt-form-group">
+                        <label>Custom Site Logo URL</label>
+                        <input type="text" name="ds-logo" placeholder="https://..." 
+                            value="<?php echo esc_attr(get_option('ds-logo') ?? ''); ?>">
+                    </div>
                 </div>
-                <div class="dpt-ds-field" style="margin-top: 15px;">
-                    <label>Custom Site Logo URL</label>
-                    <input type="text" name="ds-logo" placeholder="https://..." value="<?php echo esc_html(get_option("ds-logo")); ?>">
-                </div>
-                <hr style="margin: 20px 0;">
-                <div class="dpt-ds-row">
-                    <div class="dpt-ds-field">
+                
+                <hr class="dpt-divider">
+                
+                <div class="dpt-form-row">
+                    <div class="dpt-form-group">
                         <label>Scrolling Text</label>
-                        <input type="text" name="ds-scroll-text" value="<?php echo esc_html(stripslashes(get_option("ds-scroll-text"))); ?>">
+                        <input type="text" name="ds-scroll-text" 
+                            value="<?php echo esc_attr(get_option('ds-scroll-text') ?? ''); ?>">
                     </div>
-                    <div class="dpt-ds-field">
+                    <div class="dpt-form-group">
                         <label>Scrolling Speed (1-100)</label>
-                        <input type="number" name="ds-scroll-speed" min="10" max="100" value="<?php echo esc_html(get_option("ds-scroll-speed")); ?>">
+                        <input type="number" name="ds-scroll-speed" min="10" max="100" 
+                            value="<?php echo esc_attr(get_option('ds-scroll-speed') ?? 30); ?>">
                     </div>
-                </div>
-                <div class="dpt-ds-field" style="margin-top: 15px;">
-                    <label>Blink Text</label>
-                    <input type="text" name="ds-blink-text" value="<?php echo esc_html(stripslashes(get_option("ds-blink-text"))); ?>">
+                    <div class="dpt-form-group">
+                        <label>Blink Text</label>
+                        <input type="text" name="ds-blink-text" 
+                            value="<?php echo esc_attr(get_option('ds-blink-text') ?? ''); ?>">
+                    </div>
                 </div>
             </div>
         </div>
-
-        <!-- Slider Settings (conditional) -->
-        <div class="dpt-ds-accordion <?php echo $isSliderActive ? 'active' : ''; ?>" id="dpt-slider-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider Settings</div>
-            <div class="accordion-content">
-                <div class="dpt-ds-row" style="margin-bottom: 20px;">
-                    <div class="dpt-ds-field">
+        <?php
+    }
+    
+    private function renderSliderSettings(): void {
+        $displayCount = $this->sliderSettings['displayCount'];
+        $isActive = $this->sliderSettings['isActive'];
+        
+        ?>
+        <div class="dpt-section <?php echo $isActive ? 'active' : ''; ?>" id="dpt-slider-section">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">🖼️ Slider Settings</div>
+            <div class="dpt-section-content">
+                <div class="dpt-form-row">
+                    <div class="dpt-form-group">
                         <label>Re-display Next Prayer After # Slides</label>
-                        <input type="number" name="nextPrayerSlide" min="0" value="<?php echo esc_html(get_option("nextPrayerSlide")); ?>">
+                        <input type="number" name="nextPrayerSlide" min="0" 
+                            value="<?php echo esc_attr(get_option('nextPrayerSlide') ?? 0); ?>">
                     </div>
-                    <div class="dpt-ds-field">
+                    <div class="dpt-form-group">
                         <label>Transition Effect</label>
-                        <div style="display: flex; gap: 15px; margin-top: 5px;">
-                            <label><input type="radio" name="transitionEffect" value="slide" <?php if(get_option("transitionEffect") === 'slide'){ echo 'checked'; } ?>> Slide</label>
-                            <label><input type="radio" name="transitionEffect" value="carousel-fade" <?php if(get_option("transitionEffect") === 'carousel-fade'){ echo 'checked'; } ?>> Fade</label>
+                        <div style="display: flex; gap: 15px; margin-top: 8px;">
+                            <label>
+                                <input type="radio" name="transitionEffect" value="slide" 
+                                    <?php checked(get_option('transitionEffect'), 'slide'); ?>> Slide
+                            </label>
+                            <label>
+                                <input type="radio" name="transitionEffect" value="carousel-fade" 
+                                    <?php checked(get_option('transitionEffect'), 'carousel-fade'); ?>> Fade
+                            </label>
                         </div>
                     </div>
-                    <div class="dpt-ds-field">
+                    <div class="dpt-form-group">
                         <label>Transition Speed (seconds)</label>
-                        <input type="number" name="transitionSpeed" min="0" placeholder="5" value="<?php echo esc_html(get_option("transitionSpeed") / 1000); ?>">
+                        <input type="number" name="transitionSpeed" min="0" placeholder="5" 
+                            value="<?php echo esc_attr((get_option('transitionSpeed') ?? 5000) / 1000); ?>">
                     </div>
                 </div>
                 
-                <hr style="margin: 20px 0;">
+                <hr class="dpt-divider">
                 
-                <p style="margin-bottom: 15px; color: #666;">Click <strong>"🖼️ Select from Media"</strong> to choose images from your gallery. Maximum 7 sliders.</p>
-                <div class="dpt-sliders-container">
-                    <?php for ($i = 1; $i <= 11; $i++): ?>
-                    <div class="dpt-slider-section<?php echo ($i > $displayCount) ? ' dpt-slider-hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
-                        <h4>Slider #<?php echo $i; ?></h4>
-                        <div class="dpt-slider-input-group">
-                            <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
-                            <input type="text" class="slider-text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" value="<?php echo esc_html(stripslashes(get_option("slider$i")) )?>">
-                            <?php echo displayImage(get_option("slider$i")); ?>
-                        </div>
-                        <div class="dpt-slider-input-group">
-                            <span style="color: #666; font-size: 12px;">Optional link:</span>
-                            <input type="text" class="slider-text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" value="<?php echo esc_html(get_option("slider{$i}Url")); ?>">
-                        </div>
+                <p style="color: #666; margin-bottom: 15px;">
+                    Click <strong>"🖼️ Select from Media"</strong> to choose images. Maximum <?php echo self::MAX_SLIDERS; ?> sliders.
+                </p>
+                
+                <?php for ($i = 1; $i <= self::TOTAL_SLIDER_FIELDS; $i++): ?>
+                <div class="dpt-slider-card <?php echo $i > $displayCount ? 'hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
+                    <h4>Slider #<?php echo $i; ?></h4>
+                    <div class="dpt-slider-input-row">
+                        <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
+                        <input type="text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" 
+                            value="<?php echo esc_attr(get_option("slider$i") ?? ''); ?>">
+                        <?php echo $this->displayImage(get_option("slider$i")); ?>
                     </div>
-                    <?php endfor; ?>
-                    
-                    <button type="button" class="dpt-add-slider-btn" id="dpt-add-slider"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
+                    <div class="dpt-slider-input-row">
+                        <span style="color: #666; font-size: 12px; min-width: 80px;">Optional link:</span>
+                        <input type="text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" 
+                            value="<?php echo esc_attr(get_option("slider{$i}Url") ?? ''); ?>">
+                    </div>
                 </div>
+                <?php endfor; ?>
+                
+                <button type="button" class="dpt-add-btn" id="dpt-add-slider"
+                    <?php echo $displayCount >= self::MAX_SLIDERS ? 'style="display:none;"' : ''; ?>>
+                    + Add Another Slider
+                </button>
             </div>
         </div>
-
-        <!-- Template Selection (before Advanced) -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
-            <div class="accordion-content">
+        <?php
+    }
+    
+    private function renderTemplateSettings(): void {
+        ?>
+        <div class="dpt-section">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">🎨 Template Selection (Optional)</div>
+            <div class="dpt-section-content">
                 <div class="dpt-template-grid">
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
-                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
+                    <?php foreach ($this->templates as $key => $template): ?>
+                    <label class="dpt-template-card <?php echo $template['value'] === $key ? 'selected' : ''; ?>">
+                        <img src="<?php echo esc_url($template['image']); ?>" alt="<?php echo esc_attr($template['name']); ?>">
+                        <div>
+                            <input type="radio" name="ds-template" value="<?php echo esc_attr($key); ?>"
+                                <?php checked($template['value'], $key); ?>>
+                            <strong><?php echo esc_html($template['name']); ?></strong>
+                        </div>
                     </label>
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
-                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
-                    </label>
+                    <?php endforeach; ?>
                     <label class="dpt-template-card" style="opacity: 0.6;">
                         <div style="padding: 40px 10px;">Coming Soon</div>
                         <div><input type="radio" disabled> <strong>Your Design</strong></div>
@@ -218,23 +298,31 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
                 </div>
             </div>
         </div>
-
-        <!-- Advanced -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🔧 Advanced</div>
-            <div class="accordion-content">
-                <div class="dpt-ds-field">
-                    <label>Additional CSS <span class="hint">(advanced users only)</span></label>
-                    <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }"><?php echo esc_html(get_option("ds-additional-css")); ?></textarea>
+        <?php
+    }
+    
+    private function renderAdvancedSettings(): void {
+        ?>
+        <div class="dpt-section">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">🔧 Advanced</div>
+            <div class="dpt-section-content">
+                <div class="dpt-form-group">
+                    <label>Additional CSS <span class="dpt-hint">(advanced users only)</span></label>
+                    <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }">
+                        <?php echo esc_textarea(get_option('ds-additional-css') ?? ''); ?>
+                    </textarea>
                 </div>
             </div>
         </div>
-
-        <!-- How to Use (last) -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">❓ How to Use</div>
-            <div class="accordion-content">
-                <div class="instructions-box">
+        <?php
+    }
+    
+    private function renderInstructions(): void {
+        ?>
+        <div class="dpt-section">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">❓ How to Use</div>
+            <div class="dpt-section-content">
+                <div class="dpt-instructions">
                     <h3>Quick Start Guide</h3>
                     <ol>
                         <li><a href="<?php echo admin_url('post-new.php?post_type=page'); ?>">Create a new page</a></li>
@@ -244,85 +332,103 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
                     <h3>Shortcode Options</h3>
                     <ul>
                         <li><code>[digital_screen view='vertical']</code> - Mobile display</li>
-                        <li><code>[digital_screen view='presentation']</code> - Slides only (no prayer times)</li>
-                        <li><code>[digital_screen slides='url1,url2']</code> - Override slider images</li>
+                        <li><code>[digital_screen view='presentation']</code> - Slides only</li>
                         <li><code>[digital_screen dim=10]</code> - Dim after 10 mins</li>
-                        <li><code>[digital_screen scroll='Your text']</code> - Override scroll message</li>
-                        <li><code>[digital_screen blink='Alert text']</code> - Override blink text</li>
-                        <li><code>[digital_screen scroll_link='https://...']</code> - Make scroll text clickable</li>
+                        <li><code>[digital_screen scroll='text']</code> - Override scroll</li>
+                        <li><code>[digital_screen blink='text']</code> - Override blink</li>
                     </ul>
                 </div>
             </div>
         </div>
-
-    </div>
-
-    <div style="margin-top: 20px;">
-        <?php submit_button('Save All Settings', 'primary', 'digitalScreen'); ?>
-    </div>
-    </form>
-</div>
-
-<script>
-function toggleDsAccordion(header) {
-    header.parentElement.classList.toggle('active');
+        <?php
+    }
+    
+    private function renderFormClose(): void {
+        ?>
+            </div>
+            <div style="margin-top: 20px;">
+                <?php submit_button('Save All Settings', 'primary', 'digitalScreen'); ?>
+            </div>
+            </form>
+        </div>
+        <?php
+    }
+    
+    private function renderScripts(): void {
+        wp_enqueue_media();
+        ?>
+        <script>
+        function toggleDptSection(header) {
+            header.parentElement.classList.toggle('active');
+        }
+        
+        window.updateDisplayMode = function(value) {
+            const sliderSection = document.getElementById('dpt-slider-section');
+            const quranInput = document.getElementById('quran-chbox-hidden');
+            const sliderInput = document.getElementById('slider-chbox-hidden');
+            
+            if (value === 'slider') {
+                quranInput.value = '';
+                sliderInput.value = 'slider';
+                sliderSection.classList.remove('hidden');
+                sliderSection.classList.add('active');
+            } else if (value === 'quran') {
+                sliderInput.value = '';
+                quranInput.value = 'displayQuran';
+                sliderSection.classList.remove('active');
+                sliderSection.classList.add('hidden');
+            }
+        };
+        
+        jQuery(document).ready(function($) {
+            // Add slider button
+            $('#dpt-add-slider').on('click', function() {
+                const hidden = $('.dpt-slider-card.hidden').first();
+                if (hidden.length) {
+                    hidden.removeClass('hidden');
+                    if ($('.dpt-slider-card:not(.hidden)').length >= 7) {
+                        $(this).hide();
+                    }
+                }
+            });
+            
+            // Media gallery
+            $(document).on('click', '.dpt-media-btn', function(e) {
+                e.preventDefault();
+                const inputName = $(this).data('input');
+                const frame = wp.media({
+                    title: 'Select Image for Slider',
+                    button: { text: 'Use this image' },
+                    multiple: false
+                });
+                
+                frame.on('select', function() {
+                    const attachment = frame.state().get('selection').first().toJSON();
+                    $('input[name="' + inputName + '"]').val(attachment.url).trigger('change');
+                });
+                
+                frame.open();
+            });
+            
+            // Template selection
+            $('.dpt-template-card').on('click', function() {
+                $(this).find('input[type="radio"]').prop('checked', true);
+                $('.dpt-template-card').removeClass('selected');
+                $(this).addClass('selected');
+            });
+        });
+        </script>
+        <?php
+    }
+    
+    private function displayImage(string $url = ''): string {
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+            return '<img src="' . esc_url($url) . '" style="max-height: 30px; margin-left: 10px;">';
+        }
+        return '';
+    }
 }
 
-jQuery(document).ready(function($) {
-    // Handle exclusive display mode selection
-    window.updateDisplayMode = function(value) {
-        if (value === 'slider') {
-            $('#quran-chbox-hidden').val('');
-            $('#slider-chbox-hidden').val('slider');
-            $('#dpt-slider-accordion').removeClass('dpt-hidden');
-            $('#dpt-slider-accordion').addClass('active');
-        } else if (value === 'quran') {
-            $('#slider-chbox-hidden').val('');
-            $('#quran-chbox-hidden').val('displayQuran');
-            $('#dpt-slider-accordion').removeClass('active');
-            $('#dpt-slider-accordion').addClass('dpt-hidden');
-        }
-    };
-    
-    // Add Another Slider button
-    $('#dpt-add-slider').on('click', function() {
-        var $hidden = $('.dpt-slider-section.dpt-slider-hidden').first();
-        if ($hidden.length) {
-            $hidden.removeClass('dpt-slider-hidden');
-            if ($('.dpt-slider-section:not(.dpt-slider-hidden)').length >= 7) {
-                $(this).hide();
-            }
-        }
-    });
-    
-    // Media gallery button
-    $(document).on('click', '.dpt-media-btn', function(e) {
-        e.preventDefault();
-        var btn = $(this);
-        var inputName = btn.data('input');
-        
-        var frame = wp.media({
-            title: 'Select Image for Slider',
-            button: { text: 'Use this image' },
-            multiple: false
-        });
-        
-        frame.on('select', function() {
-            var attachment = frame.state().get('selection').first().toJSON();
-            $('input[name="' + inputName + '"]').val(attachment.url).trigger('change');
-        });
-        
-        frame.open();
-    });
-
-    // Template card selection
-    $('.dpt-template-card').on('click', function() {
-        $(this).find('input[type="radio"]').prop('checked', true);
-        $('.dpt-template-card').removeClass('selected');
-        $(this).addClass('selected');
-    });
-});
-</script>
-<?php 
-wp_enqueue_media();
-?>
+// Render the settings
+$settings = new DigitalScreenSettings();
+$settings->render();

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -127,6 +127,8 @@ class DigitalScreenSettings {
             .dpt-template-card:hover { border-color: #2271b1; }
             .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }
+            .dpt-template-card.dpt-template-placeholder { opacity: 0.8; cursor: pointer; border-style: dashed; }
+            .dpt-template-card.dpt-template-placeholder:hover { border-color: #2271b1; background: #f5f5f5; }
             
             .dpt-instructions { background: #f0f0f1; padding: 15px; border-radius: 8px; }
             .dpt-instructions h3 { margin: 0 0 12px 0; color: #2271b1; }
@@ -290,10 +292,13 @@ class DigitalScreenSettings {
                         </div>
                     </label>
                     <?php endforeach; ?>
-                    <label class="dpt-template-card" style="opacity: 0.6;">
-                        <div style="padding: 40px 10px;">Coming Soon</div>
-                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
-                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
+                    <label class="dpt-template-card dpt-template-placeholder">
+                        <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEzMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEzMCIgZmlsbD0iI2YzZjRmNiIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LXNpemU9IjE0IiBmaWxsPSIjOTk5IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkeT0iLjNlbSI+TGV0J3MgZGlzc3Vzc+PC90ZXh0Pjx0ZXh0IHg9IjUwJSIgeT0iNjAlIiBmb250LXNpemU9IjEyIiBmaWxsPSIjNjY2IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj7CoCBEcm9wIHRoZSBpbWFnZSBobZXJlPC90ZXh0Pjwvc3ZnPg==" alt="Add your template">
+                        <div>
+                            <input type="radio" name="ds-template" value="custom" disabled>
+                            <strong>Add your template here</strong>
+                        </div>
+                        <small><a href="mailto:mmrs151@gmail.com">Let's discuss</a></small>
                     </label>
                 </div>
             </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -100,6 +100,17 @@ class DigitalScreenSettings {
 
             .dpt-form-row-wide { margin-top: 20px; }
             .dpt-image-preview { max-height: 30px; margin-left: 10px; }
+            .dpt-image-preview:hover { 
+                position: fixed; 
+                top: 50%; left: 50%; 
+                transform: translate(-50%, -50%); 
+                max-height: 80vh; 
+                max-width: 80vw; 
+                z-index: 9999; 
+                background: #fff; 
+                padding: 10px;
+                box-shadow: 0 0 20px rgba(0,0,0,0.5);
+            }
         </style>
         <?php
     }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -108,29 +108,7 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
     
     <div id="dpt-ds-accordions">
         
-        <!-- Template Selection (at top, optional) -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
-            <div class="accordion-content">
-                <div class="dpt-template-grid">
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
-                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
-                    </label>
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
-                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
-                    </label>
-                    <label class="dpt-template-card" style="opacity: 0.6;">
-                        <div style="padding: 40px 10px;">Coming Soon</div>
-                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
-                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
-                    </label>
-                </div>
-            </div>
-        </div>
-
-        <!-- General Settings -->
+        <!-- General Settings + Messages (merged, top, expanded) -->
         <div class="dpt-ds-accordion active">
             <div class="accordion-header" onclick="toggleDsAccordion(this)">⚙️ General Settings</div>
             <div class="accordion-content">
@@ -152,13 +130,7 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
                     <label>Custom Site Logo URL</label>
                     <input type="text" name="ds-logo" placeholder="https://..." value="<?php echo esc_html(get_option("ds-logo")); ?>">
                 </div>
-            </div>
-        </div>
-
-        <!-- Messages -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">💬 Messages</div>
-            <div class="accordion-content">
+                <hr style="margin: 20px 0;">
                 <div class="dpt-ds-row">
                     <div class="dpt-ds-field">
                         <label>Scrolling Text</label>
@@ -176,7 +148,7 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
             </div>
         </div>
 
-        <!-- Slider Settings (only visible when slider is active) -->
+        <!-- Slider Settings (conditional) -->
         <div class="dpt-ds-accordion <?php echo $isSliderActive ? 'active' : ''; ?>" id="dpt-slider-accordion">
             <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider Settings</div>
             <div class="accordion-content">
@@ -218,6 +190,28 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
                     <?php endfor; ?>
                     
                     <button type="button" class="dpt-add-slider-btn" id="dpt-add-slider"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Template Selection (before Advanced) -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
+            <div class="accordion-content">
+                <div class="dpt-template-grid">
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
+                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
+                    </label>
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
+                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
+                    </label>
+                    <label class="dpt-template-card" style="opacity: 0.6;">
+                        <div style="padding: 40px 10px;">Coming Soon</div>
+                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
+                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
+                    </label>
                 </div>
             </div>
         </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -1,7 +1,7 @@
 <?php
 function displayImage($slide){
     if (filter_var($slide, FILTER_VALIDATE_URL)) {
-        return  '<img src="' . esc_html($slide ) . '" style="max-height: 25px;" class="grow">';
+        return  '<img src="' . esc_html($slide ) . '" style="max-height: 30px; margin-top: 5px;" class="grow">';
     }
     return '';
 }
@@ -15,59 +15,43 @@ for ($i = 1; $i <= 11; $i++) {
 $displayCount = max(1, min($existingSliders, $maxSliders));
 ?>
 <style>
-.dpt-slider-row { display: flex; align-items: center; gap: 8px; }
-.dpt-slider-row input[type="text"] { flex: 1; }
-.dpt-media-btn { 
-    padding: 6px 10px; cursor: pointer; border: 1px solid #ccc; 
-    background: #f0f0f0; border-radius: 4px; font-size: 16px; 
+.dpt-slider-section {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 15px;
+    background: #f9f9f9;
 }
-.dpt-media-btn:hover { background: #e0e0e0; }
+.dpt-slider-section h4 {
+    margin: 0 0 10px 0;
+    color: #2271b1;
+    font-weight: 600;
+}
+.dpt-slider-input-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.dpt-slider-input-group input[type="text"] {
+    flex: 1;
+}
+.dpt-media-btn { 
+    padding: 8px 12px; cursor: pointer; border: 1px solid #ccc; 
+    background: #fff; border-radius: 4px; font-size: 14px;
+    white-space: nowrap;
+}
+.dpt-media-btn:hover { background: #e0e0e0; border-color: #2271b1; }
 .dpt-add-slider-btn {
-    margin-top: 10px; padding: 8px 16px; cursor: pointer;
+    display: inline-block; padding: 10px 20px; cursor: pointer;
     background: #2271b1; color: #fff; border: none; border-radius: 4px;
+    font-size: 14px; margin-top: 10px;
 }
 .dpt-add-slider-btn:hover { background: #1d5a8a; }
+.dpt-add-slider-btn:disabled { background: #ccc; cursor: not-allowed; }
 .dpt-slider-hidden { display: none; }
+.dpt-sliders-container { margin-top: 20px; }
 </style>
-
-<script>
-jQuery(document).ready(function($) {
-    var frame;
-    $('.dpt-media-btn').on('click', function(e) {
-        e.preventDefault();
-        var $button = $(this);
-        var $input = $button.closest('.dpt-slider-row').find('input[name="slider[]"]');
-        
-        if (frame) {
-            frame.open();
-            return;
-        }
-        
-        frame = wp.media({
-            title: 'Select Image for Slider',
-            button: { text: 'Use this image' },
-            multiple: false
-        });
-        
-        frame.on('select', function() {
-            var attachment = frame.state().get('selection').first().toJSON();
-            $input.val(attachment.url).trigger('change');
-        });
-        
-        frame.open();
-    });
-    
-    $('.dpt-add-slider-btn').on('click', function() {
-        var currentVisible = $('.ds-slides:visible').length;
-        if (currentVisible < 7) {
-            $('.ds-slides').eq(currentVisible).show();
-            if ($('.ds-slides:visible').length >= 7) {
-                $(this).hide();
-            }
-        }
-    });
-});
-</script>
 
 <h3>Masjid/Mobile screen settings</h3>
 <div class="container-fluid">
@@ -156,27 +140,30 @@ jQuery(document).ready(function($) {
                         <td>Transition Speed</td>
                         <td><input type="number" min="0" class="slider-text" name="transitionSpeed" placeholder="5" value=<?php echo esc_html(get_option("transitionSpeed")/1000 ) ?>> seconds </td>
                     </tr>
-
+                </table>
+                
+                <div class="dpt-sliders-container">
+                    <h4>Sliders <small>(click + Add Another to add more, max 7)</small></h4>
+                    
                     <?php for ($i = 1; $i <= 11; $i++): ?>
-                    <tr class="ds-slides<?php echo ($i > $displayCount) ? ' dpt-slider-hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
-                        <td>Slider #<?php echo $i; ?></td>
-                        <td>
-                            <div class="dpt-slider-row">
-                                <button type="button" class="dpt-media-btn" title="Select from Media Gallery">🖼️</button>
-                                <input type="text" class="slider-text" placeholder="Any message or image url" name="slider<?php echo $i; ?>" size="30" value="<?php echo esc_html(stripslashes(get_option("slider$i")) )?>">
-                            </div>
-                            <?php echo displayImage(get_option("slider$i")); ?>
-                            <br/>
-                            <input type="text" class="slider-text" placeholder="[optional] http(s)://  url" name="slider<?php echo $i; ?>Url" size="30" value=<?php echo esc_html(get_option("slider{$i}Url") )?>>
-                        </td>
-                    </tr>
+                    <div class="dpt-slider-section<?php echo ($i > $displayCount) ? ' dpt-slider-hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
+                        <h4>Slider #<?php echo $i; ?></h4>
+                        <div class="dpt-slider-input-group">
+                            <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
+                            <input type="text" class="slider-text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" value="<?php echo esc_html(stripslashes(get_option("slider$i")) )?>">
+                        </div>
+                        <?php echo displayImage(get_option("slider$i")); ?>
+                        <div class="dpt-slider-input-group">
+                            <span style="color: #666; font-size: 12px;">Optional link:</span>
+                            <input type="text" class="slider-text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" value="<?php echo esc_html(get_option("slider{$i}Url")); ?>">
+                        </div>
+                    </div>
                     <?php endfor; ?>
                     
-                    <tr>
-                        <td colspan="2">
-                            <button type="button" class="dpt-add-slider-btn"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
-                        </td>
-                    </tr>
+                    <button type="button" class="dpt-add-slider-btn" id="dpt-add-slider"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
+                </div>
+                
+                <table class="table" style="margin-top: 20px;">
                     <tr>
                         <td class="active-slider">Additional CSS</td>
                         <td><textarea name="ds-additional-css" cols="30"><?php echo esc_html(get_option("ds-additional-css") )?></textarea></td>
@@ -200,3 +187,43 @@ jQuery(document).ready(function($) {
     </div>
     </form>
 </div>
+
+<script>
+jQuery(document).ready(function($) {
+    // Add Another Slider button
+    $('#dpt-add-slider').on('click', function() {
+        var $hidden = $('.dpt-slider-section.dpt-slider-hidden').first();
+        if ($hidden.length) {
+            $hidden.removeClass('dpt-slider-hidden');
+            if ($('.dpt-slider-section:not(.dpt-slider-hidden)').length >= 7) {
+                $(this).hide();
+            }
+        }
+    });
+    
+    // Media gallery button
+    $(document).on('click', '.dpt-media-btn', function(e) {
+        e.preventDefault();
+        var btn = $(this);
+        var inputName = btn.data('input');
+        
+        // Create WordPress media frame
+        var frame = wp.media({
+            title: 'Select Image for Slider',
+            button: { text: 'Use this image' },
+            multiple: false
+        });
+        
+        frame.on('select', function() {
+            var attachment = frame.state().get('selection').first().toJSON();
+            $('input[name="' + inputName + '"]').val(attachment.url).trigger('change');
+        });
+        
+        frame.open();
+    });
+});
+</script>
+<?php 
+// Enqueue WordPress media uploader scripts
+wp_enqueue_media();
+?>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -15,6 +15,31 @@ for ($i = 1; $i <= 11; $i++) {
 $displayCount = max(1, min($existingSliders, $maxSliders));
 ?>
 <style>
+.dpt-ds-accordion { margin-bottom: 10px; }
+.dpt-ds-accordion .accordion-header { 
+    background: #2271b1; color: #fff; padding: 12px 15px; cursor: pointer; 
+    border-radius: 4px; display: flex; justify-content: space-between; align-items: center;
+}
+.dpt-ds-accordion .accordion-header:hover { background: #1d5a8a; }
+.dpt-ds-accordion .accordion-header:after { content: '▼'; font-size: 10px; transition: transform 0.3s; }
+.dpt-ds-accordion.active .accordion-header:after { transform: rotate(180deg); }
+.dpt-ds-accordion .accordion-content { display: none; padding: 15px; border: 1px solid #ddd; border-top: none; }
+.dpt-ds-accordion.active .accordion-content { display: block; }
+
+.dpt-ds-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 15px; }
+.dpt-ds-field { display: flex; flex-direction: column; gap: 5px; }
+.dpt-ds-field label { font-weight: 600; font-size: 13px; color: #444; }
+.dpt-ds-field input, .dpt-ds-field textarea { padding: 8px; border: 1px solid #ccc; border-radius: 4px; }
+.dpt-ds-field input:focus, .dpt-ds-field textarea:focus { outline: 2px solid #2271b1; border-color: #2271b1; }
+.dpt-ds-field .hint { font-size: 11px; color: #666; font-weight: normal; }
+
+.dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
+.dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 10px; cursor: pointer; transition: all 0.2s; }
+.dpt-template-card:hover { border-color: #2271b1; }
+.dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
+.dpt-template-card img { max-width: 100%; border-radius: 4px; }
+.dpt-template-card input { margin-top: 8px; }
+
 .dpt-slider-section {
     border: 1px solid #ddd;
     border-radius: 8px;
@@ -56,100 +81,134 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
 .dpt-add-slider-btn:disabled { background: #ccc; cursor: not-allowed; }
 .dpt-slider-hidden { display: none; }
 .dpt-sliders-container { margin-top: 20px; }
+
+.dpt-ds-checkbox { display: flex; align-items: center; gap: 8px; }
+.dpt-ds-checkbox input { width: auto; }
+.dpt-ds-checkbox label { font-weight: normal; }
+
+.dpt-ds-row { display: flex; gap: 20px; flex-wrap: wrap; }
+.dpt-ds-row .dpt-ds-field { flex: 1; min-width: 200px; }
+
+.instructions-box { background: #f0f0f1; padding: 15px; border-radius: 8px; }
+.instructions-box h3 { margin-top: 0; color: #2271b1; font-size: 16px; }
+.instructions-box code { background: #fff; padding: 2px 5px; border-radius: 3px; font-size: 12px; }
+.instructions-box li { margin-bottom: 8px; font-size: 13px; }
 </style>
 
-<h3>Masjid/Mobile screen settings</h3>
+<h3>Masjid/Mobile Screen Settings</h3>
 <div class="container-fluid">
     <form class="form-group" name="digitalScreen" method="post">
-    <div class="row ds-templates">
-        <table class="table">
-            <tr>
-                <td class="align-middle">
-                <?php $template = plugins_url('../../Assets/images/EICT.png', __FILE__)?>
-                    <a href="<?php echo $template ?>" target="_new">
-                        <img src="<?php echo $template ?>" width="200px">
-                    </a>
-                    <br/>or use shortcode <code>template='eict'</code>
-                </td>
-                <td>
-                    <?php $template = plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>
-                    <a href="<?php echo $template ?>" target="_new">
-                        <img src="<?php echo $template ?>" width="200px">
-                    </a>
-                    <br/>or use shortcode <code>template='usman'</code>
-                </td>
-                <td><img src="<?php echo plugins_url('../../Assets/images/new-template.png', __FILE__)?>" width="200px"></td>
-            </tr>
-            <tr>
-                <td style="width: 33%;"><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>><strong>Edgware Islamic Cultural Trust</strong></td>
-                <td><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>><strong>Masjid-E-Usman</strong></td>
-                <td><input type="radio" name="ds-template" value="" disabled><a href="mailto:mmrs151@gmail.com?subject=Add my design to your plugin" target="_new">Add Your Design</a></td>
-            </tr>
-        </table>
-    </div>
-    <div class="row">
-        <div class="col-sm-6 col-xs-12">
-            <?php echo wp_nonce_field( 'digitalScreen'); ?>
-                <table class="table">
-                    <tr>
-                        <td class="active-slider">Select Template</td>
-                        <td><input class="templateChbox" type="checkbox" id="template-chbox" name="template-chbox" value="template" <?php if(get_option("template-chbox") === 'template'){ echo 'checked'; } ?>></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Fading Messages </br><i><sub>seperated by full stop.</sub></i></td>
-                        <td>
-                            <textarea name="ds-fading-msg" cols="30"><?php echo esc_html(stripslashes(get_option("ds-fading-msg")) )?></textarea>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Custom Site Logo</td>
-                        <td><input type="text" class="slider-text" placeholder="Any message or image url" name="ds-logo" size="30" value=<?php echo esc_html(get_option("ds-logo") )?>></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Scrolling Text</td>
-                        <td><input type="text" class="" name="ds-scroll-text" size="30" value="<?php echo esc_html(stripslashes(get_option("ds-scroll-text")) )?>"></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Scrolling Speed</td>
-                        <td><input type="number" min="10" max="100" class="" name="ds-scroll-speed" size="30" value="<?php echo esc_html(get_option("ds-scroll-speed") )?>"></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Blink Text</td>
-                        <td><input type="text" class="slider-text" name="ds-blink-text" size="30" value="<?php echo esc_html(stripslashes(get_option("ds-blink-text")) )?>"></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Display Quran verse</td>
-                        <td><input class="oneChbox" type="checkbox" id="quran-chbox" name="quran-chbox" value="displayQuran" <?php if(get_option("quran-chbox") === 'displayQuran'){ echo 'checked'; } ?>></td>
-                    </tr>
-                    <tr>
-                        <td class="active-slider">Activate Slider</td>
-                        <td><input class="oneChbox" type="checkbox" id="slider-chbox" name="slider-chbox" value="slider" <?php if(get_option("slider-chbox") === 'slider'){ echo 'checked'; } ?>></td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Re-display Next Prayer</td>
-                        <td><input type="number" class="slider-text" placeholder=" after number of slides" name="nextPrayerSlide" min="0" value=<?php echo esc_html(get_option("nextPrayerSlide") )?>>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Transition Effect</td>
-                        <td>
-                            <label class="radio-inline">
-                                <input type="radio" name="transitionEffect" value="slide" <?php if(get_option("transitionEffect") === 'slide'){ echo 'checked'; } ?>>Slide
-                            </label>
-                            <label class="radio-inline">
-                                <input type="radio" name="transitionEffect" value="carousel-fade" <?php if(get_option("transitionEffect") === 'carousel-fade'){ echo 'checked'; } ?>>Fade
-                            </label>
-                        </td>
-                    </tr>
-                    <tr class="ds-slides">
-                        <td>Transition Speed</td>
-                        <td><input type="number" min="0" class="slider-text" name="transitionSpeed" placeholder="5" value=<?php echo esc_html(get_option("transitionSpeed")/1000 ) ?>> seconds </td>
-                    </tr>
-                </table>
-                
+    <?php echo wp_nonce_field( 'digitalScreen'); ?>
+    
+    <div id="dpt-ds-accordions">
+        <!-- Template Selection -->
+        <div class="dpt-ds-accordion active">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection</div>
+            <div class="accordion-content">
+                <div class="dpt-template-grid">
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
+                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
+                    </label>
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
+                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
+                    </label>
+                    <label class="dpt-template-card" style="opacity: 0.6;">
+                        <div style="padding: 40px 10px;">Coming Soon</div>
+                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
+                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
+                    </label>
+                </div>
+            </div>
+        </div>
+
+        <!-- General Settings -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">⚙️ General Settings</div>
+            <div class="accordion-content">
+                <div class="dpt-ds-row">
+                    <div class="dpt-ds-field">
+                        <label class="dpt-ds-checkbox">
+                            <input type="checkbox" name="template-chbox" value="template" <?php if(get_option("template-chbox") === 'template'){ echo 'checked'; } ?>>
+                            Show Template Header
+                        </label>
+                    </div>
+                    <div class="dpt-ds-field">
+                        <label class="dpt-ds-checkbox">
+                            <input type="checkbox" name="quran-chbox" value="displayQuran" <?php if(get_option("quran-chbox") === 'displayQuran'){ echo 'checked'; } ?>>
+                            Display Quran Verse
+                        </label>
+                    </div>
+                </div>
+                <div class="dpt-ds-field" style="margin-top: 15px;">
+                    <label>Fading Messages <span class="hint">(separated by full stop)</span></label>
+                    <textarea name="ds-fading-msg" rows="3"><?php echo esc_html(stripslashes(get_option("ds-fading-msg")) )?></textarea>
+                </div>
+                <div class="dpt-ds-field" style="margin-top: 15px;">
+                    <label>Custom Site Logo URL</label>
+                    <input type="text" name="ds-logo" placeholder="https://..." value="<?php echo esc_html(get_option("ds-logo")); ?>">
+                </div>
+            </div>
+        </div>
+
+        <!-- Messages -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">💬 Messages</div>
+            <div class="accordion-content">
+                <div class="dpt-ds-row">
+                    <div class="dpt-ds-field">
+                        <label>Scrolling Text</label>
+                        <input type="text" name="ds-scroll-text" value="<?php echo esc_html(stripslashes(get_option("ds-scroll-text"))); ?>">
+                    </div>
+                    <div class="dpt-ds-field">
+                        <label>Scrolling Speed (1-100)</label>
+                        <input type="number" name="ds-scroll-speed" min="10" max="100" value="<?php echo esc_html(get_option("ds-scroll-speed")); ?>">
+                    </div>
+                </div>
+                <div class="dpt-ds-field" style="margin-top: 15px;">
+                    <label>Blink Text</label>
+                    <input type="text" name="ds-blink-text" value="<?php echo esc_html(stripslashes(get_option("ds-blink-text"))); ?>">
+                </div>
+            </div>
+        </div>
+
+        <!-- Slider Settings -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider Settings</div>
+            <div class="accordion-content">
+                <div class="dpt-ds-field" style="margin-bottom: 15px;">
+                    <label class="dpt-ds-checkbox">
+                        <input type="checkbox" name="slider-chbox" value="slider" <?php if(get_option("slider-chbox") === 'slider'){ echo 'checked'; } ?>>
+                        Activate Slider
+                    </label>
+                </div>
+                <div class="dpt-ds-row">
+                    <div class="dpt-ds-field">
+                        <label>Re-display Next Prayer After # Slides</label>
+                        <input type="number" name="nextPrayerSlide" min="0" value="<?php echo esc_html(get_option("nextPrayerSlide")); ?>">
+                    </div>
+                    <div class="dpt-ds-field">
+                        <label>Transition Effect</label>
+                        <div style="display: flex; gap: 15px; margin-top: 5px;">
+                            <label><input type="radio" name="transitionEffect" value="slide" <?php if(get_option("transitionEffect") === 'slide'){ echo 'checked'; } ?>> Slide</label>
+                            <label><input type="radio" name="transitionEffect" value="carousel-fade" <?php if(get_option("transitionEffect") === 'carousel-fade'){ echo 'checked'; } ?>> Fade</label>
+                        </div>
+                    </div>
+                    <div class="dpt-ds-field">
+                        <label>Transition Speed (seconds)</label>
+                        <input type="number" name="transitionSpeed" min="0" placeholder="5" value="<?php echo esc_html(get_option("transitionSpeed") / 1000); ?>">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Sliders -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">📷 Image Sliders <span class="hint">(click to expand)</span></div>
+            <div class="accordion-content">
+                <p style="margin-bottom: 15px; color: #666;">Click <strong>"🖼️ Select from Media"</strong> to choose images from your gallery. Maximum 7 sliders.</p>
                 <div class="dpt-sliders-container">
-                    <h4>Sliders <small>(click + Add Another to add more, max 7)</small></h4>
-                    
                     <?php for ($i = 1; $i <= 11; $i++): ?>
                     <div class="dpt-slider-section<?php echo ($i > $displayCount) ? ' dpt-slider-hidden' : ''; ?>" data-slider="<?php echo $i; ?>">
                         <h4>Slider #<?php echo $i; ?></h4>
@@ -167,33 +226,57 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
                     
                     <button type="button" class="dpt-add-slider-btn" id="dpt-add-slider"<?php echo ($displayCount >= 7) ? ' style="display:none;"' : ''; ?>>+ Add Another Slider</button>
                 </div>
-                
-                <table class="table" style="margin-top: 20px;">
-                    <tr>
-                        <td class="active-slider">Additional CSS</td>
-                        <td><textarea name="ds-additional-css" cols="30"><?php echo esc_html(get_option("ds-additional-css") )?></textarea></td>
-                    </tr>   
-                </table>
-                <?php submit_button('Save changes', 'primary', 'digitalScreen'); ?>
+            </div>
         </div>
-        <div class="col-sm-6 col-xs-12" style="background-color: #eeeeee;">
-            <h3 class="pt-2"><code>INSTRUCTIONS</code></h3>
-            <li><a class="url" href="post-new.php?post_type=page">Create a new page</a></li>
-            <li>Select page template <code>Digital Screen Prayer Time</code></li>
-            <li>Use shortcode <code>[digital_screen]</code> to display in Monitor</li>
-            <li><code>[digital_screen view='vertical']</code> for Mobile diaplay</li>
-            <li><code>[digital_screen view='presentation']</code> display slides only, hiding prayer time</li>
-            <li><code>[digital_screen slides="image1Url,image2Url,...image11Url"]</code> Override slides</li>
-            <li><code>[digital_screen view='vertical' dim=10]</code> to dim vertically screen for 10 mins when prayer starts</li>
-            <li><code>[digital_screen view='vertical' dim=10 scroll='any text']</code> to override scrolling message</li>
-            <li><code>[digital_screen view='vertical' dim=10 blink='any text']</code> to override blinking alert message</li>
-            <li><code>[digital_screen view='vertical' blink='any text' blnk_link='https://valid.url' scroll='any text' scroll_link='https://valid.url']</code> Allows mobile user to click on the text and possibly pay donation</li>
+
+        <!-- Advanced -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🔧 Advanced</div>
+            <div class="accordion-content">
+                <div class="dpt-ds-field">
+                    <label>Additional CSS <span class="hint">(advanced users only)</span></label>
+                    <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }"><?php echo esc_html(get_option("ds-additional-css")); ?></textarea>
+                </div>
+            </div>
         </div>
+
+        <!-- Instructions -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">❓ How to Use</div>
+            <div class="accordion-content">
+                <div class="instructions-box">
+                    <h3>Quick Start Guide</h3>
+                    <ol>
+                        <li><a href="<?php echo admin_url('post-new.php?post_type=page'); ?>">Create a new page</a></li>
+                        <li>Select page template: <code>Digital Screen Prayer Time</code></li>
+                        <li>Add shortcode: <code>[digital_screen]</code></li>
+                    </ol>
+                    <h3>Shortcode Options</h3>
+                    <ul>
+                        <li><code>[digital_screen view='vertical']</code> - Mobile display</li>
+                        <li><code>[digital_screen view='presentation']</code> - Slides only (no prayer times)</li>
+                        <li><code>[digital_screen slides='url1,url2']</code> - Override slider images</li>
+                        <li><code>[digital_screen dim=10]</code> - Dim after 10 mins</li>
+                        <li><code>[digital_screen scroll='Your text']</code> - Override scroll message</li>
+                        <li><code>[digital_screen blink='Alert text']</code> - Override blink text</li>
+                        <li><code>[digital_screen scroll_link='https://...']</code> - Make scroll text clickable</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div style="margin-top: 20px;">
+        <?php submit_button('Save All Settings', 'primary', 'digitalScreen'); ?>
     </div>
     </form>
 </div>
 
 <script>
+function toggleDsAccordion(header) {
+    header.parentElement.classList.toggle('active');
+}
+
 jQuery(document).ready(function($) {
     // Add Another Slider button
     $('#dpt-add-slider').on('click', function() {
@@ -212,7 +295,6 @@ jQuery(document).ready(function($) {
         var btn = $(this);
         var inputName = btn.data('input');
         
-        // Create WordPress media frame
         var frame = wp.media({
             title: 'Select Image for Slider',
             button: { text: 'Use this image' },
@@ -226,9 +308,15 @@ jQuery(document).ready(function($) {
         
         frame.open();
     });
+
+    // Template card selection
+    $('.dpt-template-card').on('click', function() {
+        $(this).find('input[type="radio"]').prop('checked', true);
+        $('.dpt-template-card').removeClass('selected');
+        $(this).addClass('selected');
+    });
 });
 </script>
 <?php 
-// Enqueue WordPress media uploader scripts
 wp_enqueue_media();
 ?>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -80,6 +80,10 @@ class DigitalScreenSettings {
             .dpt-add-btn:hover { background: #1d5a8a; }
             .dpt-add-btn-hidden { display: none; }
             
+            .dpt-slider-url-label { font-size: 11px; color: #666; min-width: 70px; flex-shrink: 0; }
+            .dpt-slider-input-row input[name^="slider"][name$="Url"] { font-size: 12px; padding: 6px; }
+            .dpt-image-preview { max-height: 28px; margin-left: 8px; }
+            
             .dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
             .dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 12px; cursor: pointer; }
             .dpt-template-card:hover { border-color: #2271b1; }
@@ -99,28 +103,6 @@ class DigitalScreenSettings {
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
 
             .dpt-form-row-wide { margin-top: 20px; }
-            .dpt-image-preview { max-height: 30px; margin-left: 10px; cursor: pointer; }
-            #dpt-image-enlarged {
-                display: none;
-                position: fixed;
-                z-index: 9999;
-                background: #fff;
-                padding: 15px;
-                box-shadow: 0 0 30px rgba(0,0,0,0.5);
-                border-radius: 8px;
-                max-width: 45vw;
-                max-height: 45vh;
-            }
-            #dpt-image-enlarged.show {
-                display: block;
-                animation: dptZoomIn 0.3s ease-out;
-            }
-            @keyframes dptZoomIn {
-                from { opacity: 0; transform: scale(0.8); }
-                to { opacity: 1; transform: scale(1); }
-            }
-                transform: scale(1);
-            }
         </style>
         <?php
     }
@@ -352,31 +334,12 @@ class DigitalScreenSettings {
     private function renderScripts(): void {
         wp_enqueue_media();
         ?>
-        <div id="dpt-image-enlarged"></div>
         <script>
         function toggleDptSection(header) {
             header.parentElement.classList.toggle('active');
         }
         
         jQuery(document).ready(function($) {
-            // Image hover enlarge
-            $('.dpt-image-preview').on('mouseenter', function() {
-                var src = $(this).attr('src');
-                var offset = $(this).offset();
-                var width = $(this).width();
-                var height = $(this).height();
-                
-                $('#dpt-image-enlarged').html('<img src="' + src + '" style="max-width:100%;max-height:100%;">');
-                $('#dpt-image-enlarged')
-                    .css({
-                        left: offset.left,
-                        top: offset.top + 10
-                    })
-                    .addClass('show');
-            }).on('mouseleave', function() {
-                $('#dpt-image-enlarged').removeClass('show');
-            });
-            
             // Display mode selection - group 1 (default/template)
             $('input[name="displayMode"]').on('change', function() {
                 const value = $(this).val();

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -1,66 +1,12 @@
 <?php
 /**
  * Digital Screen Settings Admin Page
- * 
- * Handles configuration for digital screen display options including:
- * - Display mode (Quran verse or Slider)
- * - Messages (scrolling, blink text)
- * - Slider images with media gallery
- * - Template selection
- * - Advanced CSS
  */
 
 class DigitalScreenSettings {
     
     const MAX_SLIDERS = 7;
     const TOTAL_SLIDER_FIELDS = 11;
-    
-    private array $templates = [];
-    private array $displayOptions = [];
-    private array $sliderSettings = [];
-    
-    public function __construct() {
-        $this->loadSettings();
-    }
-    
-    private function loadSettings(): void {
-        $savedTemplate = get_option('dsTemplate') ?? '';
-        
-        $this->templates = [
-            'eict' => [
-                'name' => 'Edgware ICT',
-                'image' => plugins_url('../../Assets/images/EICT.png', __FILE__),
-                'isSelected' => $savedTemplate === 'eict'
-            ],
-            'usman' => [
-                'name' => 'Masjid-E-Usman',
-                'image' => plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__),
-                'isSelected' => $savedTemplate === 'usman'
-            ]
-        ];
-        
-        $this->displayOptions = [
-            'quran' => get_option('quran-chbox') === 'displayQuran',
-            'slider' => get_option('slider-chbox') === 'slider'
-        ];
-        
-        $this->sliderSettings = $this->loadSliderSettings();
-    }
-    
-    private function loadSliderSettings(): array {
-        $count = 0;
-        for ($i = 1; $i <= self::TOTAL_SLIDER_FIELDS; $i++) {
-            if (!empty(get_option("slider$i"))) {
-                $count = max($count, $i);
-            }
-        }
-        
-        return [
-            'displayCount' => max(1, min($count, self::MAX_SLIDERS)),
-            'isActive' => $this->displayOptions['slider'],
-            'maxSliders' => self::MAX_SLIDERS
-        ];
-    }
     
     public function render(): void {
         $this->renderStyles();
@@ -104,7 +50,6 @@ class DigitalScreenSettings {
             
             .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; }
             .dpt-option-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
-            .dpt-option-group input[type="radio"], .dpt-option-group input[type="checkbox"] { width: auto; }
             
             .dpt-slider-card {
                 border: 1px solid #ddd; border-radius: 8px; padding: 15px; margin-bottom: 12px;
@@ -129,19 +74,11 @@ class DigitalScreenSettings {
             .dpt-template-card:hover { border-color: #2271b1; }
             .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }
-            .dpt-template-card input[type="radio"] { margin: 5px; }
-            .dpt-template-card.dpt-template-placeholder { opacity: 0.8; cursor: pointer; border-style: dashed; }
-            .dpt-template-card.dpt-template-placeholder:hover { border-color: #2271b1; background: #f5f5f5; }
-            .dpt-placeholder-img { 
-                height: 100px; background: #e0e0e0; border-radius: 4px; margin-bottom: 8px;
-                display: flex; align-items: center; justify-content: center;
-                color: #888; font-size: 13px; border: 2px dashed #bbb;
-            }
+            .dpt-template-card.dpt-template-placeholder { opacity: 0.8; border-style: dashed; }
             
             .dpt-instructions { background: #f0f0f1; padding: 15px; border-radius: 8px; }
             .dpt-instructions h3 { margin: 0 0 12px 0; color: #2271b1; }
             .dpt-instructions code { background: #fff; padding: 2px 5px; border-radius: 3px; }
-            .dpt-instructions li { margin-bottom: 6px; }
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
         </style>
         <?php
@@ -158,29 +95,37 @@ class DigitalScreenSettings {
     }
     
     private function renderGeneralSettings(): void {
-        $isActive = $this->sliderSettings['isActive'];
+        $sliderActive = get_option('slider-chbox') === 'slider';
+        $templateActive = get_option('template-chbox') === 'template';
         ?>
         <div class="dpt-section active">
             <div class="dpt-section-header" onclick="toggleDptSection(this)">⚙️ General Settings</div>
             <div class="dpt-section-content">
                 <div class="dpt-option-group">
                     <label>
+                        <input type="radio" name="displayMode" value="default" 
+                            <?php echo (!$sliderActive && !$templateActive) ? 'checked' : ''; ?>>
+                        Default Layout
+                    </label>
+                    <label>
                         <input type="radio" name="displayMode" value="quran" 
-                            <?php checked($this->displayOptions['quran']); ?> 
-                            onchange="updateDisplayMode(this.value)">
+                            <?php echo get_option('quran-chbox') === 'displayQuran' ? 'checked' : ''; ?>>
                         Display Quran Verse
                     </label>
                     <label>
                         <input type="radio" name="displayMode" value="slider" 
-                            <?php checked($this->displayOptions['slider']); ?> 
-                            onchange="updateDisplayMode(this.value)">
+                            <?php echo $sliderActive ? 'checked' : ''; ?>>
                         Activate Slider
                     </label>
+                    <label>
+                        <input type="checkbox" id="template-chbox" 
+                            <?php echo $templateActive ? 'checked' : ''; ?>>
+                        Activate Template
+                    </label>
                 </div>
-                <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" 
-                    value="<?php echo esc_attr(get_option('quran-chbox')); ?>">
-                <input type="hidden" name="slider-chbox" id="slider-chbox-hidden" 
-                    value="<?php echo esc_attr(get_option('slider-chbox')); ?>">
+                <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" value="<?php echo esc_attr(get_option('quran-chbox') ?? ''); ?>">
+                <input type="hidden" name="slider-chbox" id="slider-chbox-hidden" value="<?php echo esc_attr(get_option('slider-chbox') ?? ''); ?>">
+                <input type="hidden" name="template-chbox" id="template-chbox-hidden" value="<?php echo esc_attr(get_option('template-chbox') ?? ''); ?>">
                 
                 <div class="dpt-form-row">
                     <div class="dpt-form-group" style="flex: 2;">
@@ -219,11 +164,11 @@ class DigitalScreenSettings {
     }
     
     private function renderSliderSettings(): void {
-        $displayCount = $this->sliderSettings['displayCount'];
-        $isActive = $this->sliderSettings['isActive'];
+        $displayCount = $this->getDisplayCount();
+        $sliderActive = get_option('slider-chbox') === 'slider';
         
         ?>
-        <div class="dpt-section <?php echo $isActive ? 'active' : ''; ?>" id="dpt-slider-section">
+        <div class="dpt-section <?php echo $sliderActive ? 'active' : ''; ?>" id="dpt-slider-section">
             <div class="dpt-section-header" onclick="toggleDptSection(this)">🖼️ Slider Settings</div>
             <div class="dpt-section-content">
                 <div class="dpt-form-row">
@@ -235,14 +180,8 @@ class DigitalScreenSettings {
                     <div class="dpt-form-group">
                         <label>Transition Effect</label>
                         <div style="display: flex; gap: 15px; margin-top: 8px;">
-                            <label>
-                                <input type="radio" name="transitionEffect" value="slide" 
-                                    <?php checked(get_option('transitionEffect'), 'slide'); ?>> Slide
-                            </label>
-                            <label>
-                                <input type="radio" name="transitionEffect" value="carousel-fade" 
-                                    <?php checked(get_option('transitionEffect'), 'carousel-fade'); ?>> Fade
-                            </label>
+                            <label><input type="radio" name="transitionEffect" value="slide" <?php echo get_option('transitionEffect') === 'slide' ? 'checked' : ''; ?>> Slide</label>
+                            <label><input type="radio" name="transitionEffect" value="carousel-fade" <?php echo get_option('transitionEffect') === 'carousel-fade' ? 'checked' : ''; ?>> Fade</label>
                         </div>
                     </div>
                     <div class="dpt-form-group">
@@ -285,30 +224,33 @@ class DigitalScreenSettings {
     }
     
     private function renderTemplateSettings(): void {
+        $savedTemplate = get_option('dsTemplate') ?? '';
+        $templateActive = get_option('template-chbox') === 'template';
         ?>
-        <div class="dpt-section">
-            <div class="dpt-section-header" onclick="toggleDptSection(this)">🎨 Template Selection (Optional)</div>
+        <div class="dpt-section <?php echo $templateActive ? 'active' : 'hidden'; ?>" id="dpt-template-section">
+            <div class="dpt-section-header" onclick="toggleDptSection(this)">🎨 Template Selection</div>
             <div class="dpt-section-content">
+                <p style="color: #666; margin-bottom: 15px;">
+                    Select a template design for your digital screen. This will replace the default layout.
+                </p>
                 <div class="dpt-template-grid">
-                    <?php foreach ($this->templates as $key => $template): ?>
-                    <label class="dpt-template-card <?php echo $template['isSelected'] ? 'selected' : ''; ?>" onclick="selectTemplate('<?php echo esc_js($key); ?>', this)">
-                        <img src="<?php echo esc_url($template['image']); ?>" alt="<?php echo esc_attr($template['name']); ?>">
-                        <div>
-                            <input type="radio" name="ds-template" value="<?php echo esc_attr($key); ?>"
-                                <?php checked($template['isSelected']); ?>>
-                            <strong><?php echo esc_html($template['name']); ?></strong>
-                        </div>
+                    <label class="dpt-template-card <?php echo $savedTemplate === 'eict' ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__); ?>" alt="EICT">
+                        <div><input type="radio" name="ds-template" value="eict" <?php echo $savedTemplate === 'eict' ? 'checked' : ''; ?>> <strong>Edgware ICT</strong></div>
                     </label>
-                    <?php endforeach; ?>
+                    <label class="dpt-template-card <?php echo $savedTemplate === 'usman' ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__); ?>" alt="Usman">
+                        <div><input type="radio" name="ds-template" value="usman" <?php echo $savedTemplate === 'usman' ? 'checked' : ''; ?>> <strong>Masjid-E-Usman</strong></div>
+                    </label>
                     <label class="dpt-template-card dpt-template-placeholder">
-                        <div class="dpt-placeholder-img">Add your template here</div>
-                        <div>
-                            <input type="radio" name="ds-template" value="custom" disabled>
-                            <strong>Add your template here</strong>
-                        </div>
-                        <small><a href="<?php echo esc_url( 'mailto:mmrs151@gmail.com?subject=' . rawurlencode( 'Custom Template Design' ) ); ?>"><?php echo esc_html( "Let's discuss" ); ?></a></small>
+                        <div class="dpt-placeholder-img" style="height:100px;background:#e0e0e0;border-radius:4px;margin-bottom:8px;display:flex;align-items:center;justify-content:center;color:#888;font-size:13px;border:2px dashed #bbb;">Add your template here</div>
+                        <div><input type="radio" disabled> <strong>Add your template here</strong></div>
+                        <small><a href="mailto:mmrs151@gmail.com?subject=Custom Template Design">Let's discuss</a></small>
                     </label>
                 </div>
+                <p style="margin-top: 15px; color: #888; font-size: 12px;">
+                    To return to the default layout, uncheck "Activate Template" above.
+                </p>
             </div>
         </div>
         <?php
@@ -375,58 +317,60 @@ class DigitalScreenSettings {
             header.parentElement.classList.toggle('active');
         }
         
-        function selectTemplate(value, element) {
-            // Find the radio button inside the label
-            const radio = element.querySelector('input[type="radio"]');
-            if (radio) {
-                radio.checked = true;
-                radio.setAttribute('checked', 'checked');
-            }
-            
-            // Update visual selection
-            var cards = document.querySelectorAll('.dpt-template-card');
-            for (var i = 0; i < cards.length; i++) {
-                cards[i].classList.remove('selected');
-            }
-            element.classList.add('selected');
-            
-            // Debug
-            console.log('Selected template:', value, 'Radio checked:', radio ? radio.checked : 'no radio');
-            
-            // Force form to include this value
-            var form = document.querySelector('form[name="digitalScreen"]');
-            if (form) {
-                var hiddenInput = form.querySelector('input[name="ds-template-hidden"]');
-                if (!hiddenInput) {
-                    hiddenInput = document.createElement('input');
-                    hiddenInput.type = 'hidden';
-                    hiddenInput.name = 'ds-template-hidden';
-                    form.appendChild(hiddenInput);
-                }
-                hiddenInput.value = value;
-                console.log('Hidden input set to:', value);
-            }
-        }
-        
-        window.updateDisplayMode = function(value) {
-            const sliderSection = document.getElementById('dpt-slider-section');
-            const quranInput = document.getElementById('quran-chbox-hidden');
-            const sliderInput = document.getElementById('slider-chbox-hidden');
-            
-            if (value === 'slider') {
-                quranInput.value = '';
-                sliderInput.value = 'slider';
-                sliderSection.classList.remove('hidden');
-                sliderSection.classList.add('active');
-            } else if (value === 'quran') {
-                sliderInput.value = '';
-                quranInput.value = 'displayQuran';
-                sliderSection.classList.remove('active');
-                sliderSection.classList.add('hidden');
-            }
-        };
-        
         jQuery(document).ready(function($) {
+            // Display mode selection
+            $('input[name="displayMode"]').on('change', function() {
+                const value = $(this).val();
+                const sliderSection = $('#dpt-slider-section');
+                const templateSection = $('#dpt-template-section');
+                const quranInput = $('#quran-chbox-hidden');
+                const sliderInput = $('#slider-chbox-hidden');
+                const templateInput = $('#template-chbox-hidden');
+                const templateCheckbox = $('#template-chbox');
+                
+                if (value === 'slider') {
+                    quranInput.val('');
+                    sliderInput.val('slider');
+                    templateInput.val('');
+                    templateCheckbox.prop('checked', false);
+                    sliderSection.removeClass('hidden').addClass('active');
+                    templateSection.removeClass('active').addClass('hidden');
+                } else if (value === 'quran') {
+                    sliderInput.val('');
+                    templateInput.val('');
+                    templateCheckbox.prop('checked', false);
+                    quranInput.val('displayQuran');
+                    sliderSection.removeClass('active').addClass('hidden');
+                    templateSection.removeClass('active').addClass('hidden');
+                } else if (value === 'default') {
+                    sliderInput.val('');
+                    templateInput.val('');
+                    templateCheckbox.prop('checked', false);
+                    quranInput.val('');
+                    sliderSection.removeClass('active').addClass('hidden');
+                    templateSection.removeClass('active').addClass('hidden');
+                }
+            });
+            
+            // Template checkbox toggle
+            $('#template-chbox').on('change', function() {
+                const templateSection = $('#dpt-template-section');
+                const templateInput = $('#template-chbox-hidden');
+                
+                if ($(this).is(':checked')) {
+                    templateInput.val('template');
+                    templateSection.removeClass('hidden').addClass('active');
+                } else {
+                    templateInput.val('');
+                    templateSection.removeClass('active').addClass('hidden');
+                }
+            });
+            
+            // Initialize template section visibility on load
+            if (!$('#template-chbox').is(':checked')) {
+                $('#dpt-template-section').addClass('hidden');
+            }
+            
             // Add slider button
             $('#dpt-add-slider').on('click', function() {
                 const hidden = $('.dpt-slider-card.hidden').first();
@@ -458,6 +402,16 @@ class DigitalScreenSettings {
         });
         </script>
         <?php
+    }
+    
+    private function getDisplayCount(): int {
+        $count = 0;
+        for ($i = 1; $i <= self::TOTAL_SLIDER_FIELDS; $i++) {
+            if (!empty(get_option("slider$i"))) {
+                $count = max($count, $i);
+            }
+        }
+        return max(1, min($count, self::MAX_SLIDERS));
     }
     
     private function displayImage(string $url = ''): string {

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -99,17 +99,25 @@ class DigitalScreenSettings {
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
 
             .dpt-form-row-wide { margin-top: 20px; }
-            .dpt-image-preview { max-height: 30px; margin-left: 10px; transition: all 0.3s ease; }
-            .dpt-image-preview:hover { 
-                position: fixed; 
-                bottom: 20px; right: 20px; 
-                max-height: 50vh; 
-                max-width: 50vw; 
-                z-index: 9999; 
-                background: #fff; 
-                padding: 10px;
-                box-shadow: 0 0 20px rgba(0,0,0,0.5);
+            .dpt-image-preview { max-height: 30px; margin-left: 10px; }
+            #dpt-image-enlarged {
+                display: none;
+                position: fixed;
+                z-index: 9999;
+                background: #fff;
+                padding: 15px;
+                box-shadow: 0 0 30px rgba(0,0,0,0.5);
                 border-radius: 8px;
+                max-width: 45vw;
+                max-height: 45vh;
+                transition: all 0.3s ease-out;
+                opacity: 0;
+                transform: scale(0.8);
+            }
+            #dpt-image-enlarged.show {
+                display: block;
+                opacity: 1;
+                transform: scale(1);
             }
         </style>
         <?php
@@ -342,12 +350,31 @@ class DigitalScreenSettings {
     private function renderScripts(): void {
         wp_enqueue_media();
         ?>
+        <div id="dpt-image-enlarged"></div>
         <script>
         function toggleDptSection(header) {
             header.parentElement.classList.toggle('active');
         }
         
         jQuery(document).ready(function($) {
+            // Image hover enlarge
+            $('.dpt-image-preview').on('mouseenter', function() {
+                var src = $(this).attr('src');
+                var offset = $(this).offset();
+                var width = $(this).width();
+                var height = $(this).height();
+                
+                $('#dpt-image-enlarged').html('<img src="' + src + '" style="max-width:100%;max-height:100%;">');
+                $('#dpt-image-enlarged')
+                    .css({
+                        left: offset.left,
+                        top: offset.top + 10
+                    })
+                    .addClass('show');
+            }).on('mouseleave', function() {
+                $('#dpt-image-enlarged').removeClass('show');
+            });
+            
             // Display mode selection - group 1 (default/template)
             $('input[name="displayMode"]').on('change', function() {
                 const value = $(this).val();

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -48,6 +48,9 @@ class DigitalScreenSettings {
             }
             .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
             
+            .dpt-form-group { flex: 1; }
+            .dpt-form-group-wide { flex: 2; }
+            
             .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; align-items: center; }
             .dpt-option-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
             .dpt-option-group .dpt-separator { color: #999; font-weight: bold; margin: 0 10px; }
@@ -59,6 +62,9 @@ class DigitalScreenSettings {
             .dpt-slider-card h4 { margin: 0 0 12px 0; color: #2271b1; }
             .dpt-slider-input-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
             .dpt-slider-input-row input { flex: 1; }
+            .dpt-slider-url-row { display: flex; gap: 15px; margin-top: 8px; }
+            .dpt-slider-url-row span { color: #666; font-size: 12px; min-width: 80px; }
+            .dpt-slider-optional { color: #666; margin-bottom: 15px; }
             .dpt-media-btn { 
                 padding: 8px 14px; cursor: pointer; border: 1px solid #ccc; 
                 background: #fff; border-radius: 4px; white-space: nowrap;
@@ -69,6 +75,7 @@ class DigitalScreenSettings {
                 background: #2271b1; color: #fff; border: none; border-radius: 4px;
             }
             .dpt-add-btn:hover { background: #1d5a8a; }
+            .dpt-add-btn-hidden { display: none; }
             
             .dpt-template-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; text-align: center; }
             .dpt-template-card { border: 2px solid #ddd; border-radius: 8px; padding: 12px; cursor: pointer; }
@@ -76,11 +83,20 @@ class DigitalScreenSettings {
             .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }
             .dpt-template-card.dpt-template-placeholder { opacity: 0.8; border-style: dashed; }
+            .dpt-placeholder-img { 
+                height: 100px; background: #e0e0e0; border-radius: 4px; margin-bottom: 8px;
+                display: flex; align-items: center; justify-content: center;
+                color: #888; font-size: 13px; border: 2px dashed #bbb;
+            }
+            .dpt-template-note { margin-top: 15px; color: #888; font-size: 12px; }
             
             .dpt-instructions { background: #f0f0f1; padding: 15px; border-radius: 8px; }
             .dpt-instructions h3 { margin: 0 0 12px 0; color: #2271b1; }
             .dpt-instructions code { background: #fff; padding: 2px 5px; border-radius: 3px; }
             .dpt-divider { border: none; border-top: 1px solid #ddd; margin: 20px 0; }
+
+            .dpt-form-row-wide { margin-top: 20px; }
+            .dpt-image-preview { max-height: 30px; margin-left: 10px; }
         </style>
         <?php
     }
@@ -130,7 +146,7 @@ class DigitalScreenSettings {
                 <input type="hidden" name="template-chbox" id="template-chbox-hidden" value="<?php echo esc_attr(get_option('template-chbox') ?? ''); ?>">
                 
                 <div class="dpt-form-row">
-                    <div class="dpt-form-group" style="flex: 2;">
+                    <div class="dpt-form-group dpt-form-group-wide">
                         <label>Fading Messages <span class="dpt-hint">(separated by full stop)</span></label>
                         <textarea name="ds-fading-msg" rows="3"><?php echo esc_textarea(get_option('ds-fading-msg') ?? ''); ?></textarea>
                     </div>
@@ -181,7 +197,7 @@ class DigitalScreenSettings {
                     </div>
                     <div class="dpt-form-group">
                         <label>Transition Effect</label>
-                        <div style="display: flex; gap: 15px; margin-top: 8px;">
+                        <div class="dpt-slider-url-row">
                             <label><input type="radio" name="transitionEffect" value="slide" <?php echo get_option('transitionEffect') === 'slide' ? 'checked' : ''; ?>> Slide</label>
                             <label><input type="radio" name="transitionEffect" value="carousel-fade" <?php echo get_option('transitionEffect') === 'carousel-fade' ? 'checked' : ''; ?>> Fade</label>
                         </div>
@@ -195,7 +211,7 @@ class DigitalScreenSettings {
                 
                 <hr class="dpt-divider">
                 
-                <p style="color: #666; margin-bottom: 15px;">
+                <p class="dpt-slider-optional">
                     Click <strong>"🖼️ Select from Media"</strong> to choose images. Maximum <?php echo self::MAX_SLIDERS; ?> sliders.
                 </p>
                 
@@ -209,7 +225,7 @@ class DigitalScreenSettings {
                         <?php echo $this->displayImage(get_option("slider$i")); ?>
                     </div>
                     <div class="dpt-slider-input-row">
-                        <span style="color: #666; font-size: 12px; min-width: 80px;">Optional link:</span>
+                        <span class="dpt-slider-url-label">Optional link:</span>
                         <input type="text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" 
                             value="<?php echo esc_attr(get_option("slider{$i}Url") ?? ''); ?>">
                     </div>
@@ -217,7 +233,7 @@ class DigitalScreenSettings {
                 <?php endfor; ?>
                 
                 <button type="button" class="dpt-add-btn" id="dpt-add-slider"
-                    <?php echo $displayCount >= self::MAX_SLIDERS ? 'style="display:none;"' : ''; ?>>
+                    <?php echo $displayCount >= self::MAX_SLIDERS ? 'class="dpt-add-btn dpt-add-btn-hidden"' : 'class="dpt-add-btn"'; ?>>
                     + Add Another Slider
                 </button>
             </div>
@@ -232,7 +248,7 @@ class DigitalScreenSettings {
         <div class="dpt-section <?php echo $templateActive ? 'active' : 'hidden'; ?>" id="dpt-template-section">
             <div class="dpt-section-header" onclick="toggleDptSection(this)">🎨 Template Selection</div>
             <div class="dpt-section-content">
-                <p style="color: #666; margin-bottom: 15px;">
+                <p class="dpt-slider-optional">
                     Select a template design for your digital screen. This will replace the default layout.
                 </p>
                 <div class="dpt-template-grid">
@@ -245,12 +261,12 @@ class DigitalScreenSettings {
                         <div><input type="radio" name="ds-template" value="usman" <?php echo $savedTemplate === 'usman' ? 'checked' : ''; ?>> <strong>Masjid-E-Usman</strong></div>
                     </label>
                     <label class="dpt-template-card dpt-template-placeholder">
-                        <div class="dpt-placeholder-img" style="height:100px;background:#e0e0e0;border-radius:4px;margin-bottom:8px;display:flex;align-items:center;justify-content:center;color:#888;font-size:13px;border:2px dashed #bbb;">Add your template here</div>
+                        <div class="dpt-placeholder-img">Add your template here</div>
                         <div><input type="radio" disabled> <strong>Add your template here</strong></div>
                         <small><a href="mailto:mmrs151@gmail.com?subject=Custom Template Design">Let's discuss</a></small>
                     </label>
                 </div>
-                <p style="margin-top: 15px; color: #888; font-size: 12px;">
+                <p class="dpt-template-note">
                     To return to the default layout, uncheck "Activate Template" above.
                 </p>
             </div>
@@ -303,7 +319,7 @@ class DigitalScreenSettings {
     private function renderFormClose(): void {
         ?>
             </div>
-            <div style="margin-top: 20px;">
+            <div class="dpt-form-row-wide">
                 <?php submit_button('Save All Settings', 'primary', 'digitalScreen'); ?>
             </div>
             </form>
@@ -416,7 +432,7 @@ class DigitalScreenSettings {
     
     private function displayImage(string $url = ''): string {
         if (filter_var($url, FILTER_VALIDATE_URL)) {
-            return '<img src="' . esc_url($url) . '" style="max-height: 30px; margin-left: 10px;">';
+            return '<img src="' . esc_url($url) . '" class="dpt-image-preview">';
         }
         return '';
     }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -282,7 +282,7 @@ class DigitalScreenSettings {
                 <div class="dpt-form-group">
                     <label>Additional CSS <span class="dpt-hint">(advanced users only)</span></label>
                     <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }">
-                        <?php echo esc_textarea(get_option('ds-additional-css') ?? ''); ?>
+                        <?php echo esc_textarea(get_option('ds-additional-css') ?? 'x'); ?>asdfa
                     </textarea>
                 </div>
             </div>
@@ -339,19 +339,14 @@ class DigitalScreenSettings {
             // Display mode selection - group 1 (default/template)
             $('input[name="displayMode"]').on('change', function() {
                 const value = $(this).val();
-                const sliderSection = $('#dpt-slider-section');
                 const templateSection = $('#dpt-template-section');
-                const sliderInput = $('#slider-chbox-hidden');
                 const templateInput = $('#template-chbox-hidden');
                 
                 if (value === 'template') {
-                    sliderInput.val('');
                     templateInput.val('template');
-                    sliderSection.removeClass('active').addClass('hidden');
                     templateSection.removeClass('hidden').addClass('active');
                 } else if (value === 'default') {
                     templateInput.val('');
-                    sliderSection.removeClass('active').addClass('hidden');
                     templateSection.removeClass('active').addClass('hidden');
                 }
             });
@@ -360,20 +355,15 @@ class DigitalScreenSettings {
             $('input[name="displayModeAlt"]').on('change', function() {
                 const value = $(this).val();
                 const sliderSection = $('#dpt-slider-section');
-                const templateSection = $('#dpt-template-section');
                 const quranInput = $('#quran-chbox-hidden');
                 const sliderInput = $('#slider-chbox-hidden');
-                const templateInput = $('#template-chbox-hidden');
                 
                 if (value === 'slider') {
                     quranInput.val('');
                     sliderInput.val('slider');
-                    templateInput.val('');
                     sliderSection.removeClass('hidden').addClass('active');
-                    templateSection.removeClass('active').addClass('hidden');
                 } else if (value === 'quran') {
                     sliderInput.val('');
-                    templateInput.val('');
                     quranInput.val('displayQuran');
                     sliderSection.removeClass('active').addClass('hidden');
                 }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -63,11 +63,11 @@ class DigitalScreenSettings {
                 background: #f9f9f9;
             }
             .dpt-slider-card h4 { margin: 0 0 12px 0; color: #2271b1; }
-            .dpt-slider-row { display: flex; gap: 15px; align-items: center; }
+            .dpt-slider-row { display: flex; gap: 20px; align-items: flex-start; }
             .dpt-slider-fields { flex: 1; }
             .dpt-slider-preview { 
-                width: 80px; 
-                height: 60px; 
+                width: 120px; 
+                height: 90px; 
                 display: flex; 
                 align-items: center; 
                 justify-content: center;
@@ -75,8 +75,9 @@ class DigitalScreenSettings {
                 border-radius: 4px;
                 background: #f9f9f9;
                 flex-shrink: 0;
+                padding: 5px;
             }
-            .dpt-slider-preview img { max-width: 100%; max-height: 100%; }
+            .dpt-slider-preview img { max-width: 100%; max-height: 100%; object-fit: contain; }
             .dpt-slider-input-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
             .dpt-slider-input-row input { flex: 1; }
             .dpt-slider-url-row { display: flex; gap: 15px; margin-top: 8px; }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -1,7 +1,7 @@
 <?php
 function displayImage($slide){
     if (filter_var($slide, FILTER_VALIDATE_URL)) {
-        return  '<img src="' . esc_html($slide ) . '" style="max-height: 30px; margin-top: 5px;" class="grow">';
+        return  '<img src="' . esc_html($slide ) . '" style="max-height: 30px;" class="grow">';
     }
     return '';
 }
@@ -35,6 +35,11 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
 }
 .dpt-slider-input-group input[type="text"] {
     flex: 1;
+}
+.dpt-slider-input-group img {
+    max-height: 30px;
+    margin-left: 10px;
+    vertical-align: middle;
 }
 .dpt-media-btn { 
     padding: 8px 12px; cursor: pointer; border: 1px solid #ccc; 
@@ -151,8 +156,8 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
                         <div class="dpt-slider-input-group">
                             <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
                             <input type="text" class="slider-text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" value="<?php echo esc_html(stripslashes(get_option("slider$i")) )?>">
+                            <?php echo displayImage(get_option("slider$i")); ?>
                         </div>
-                        <?php echo displayImage(get_option("slider$i")); ?>
                         <div class="dpt-slider-input-group">
                             <span style="color: #666; font-size: 12px;">Optional link:</span>
                             <input type="text" class="slider-text" placeholder="http(s):// url" name="slider<?php echo $i; ?>Url" value="<?php echo esc_html(get_option("slider{$i}Url")); ?>">

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -129,6 +129,7 @@ class DigitalScreenSettings {
             .dpt-template-card:hover { border-color: #2271b1; }
             .dpt-template-card.selected { border-color: #2271b1; background: #e7f1ff; }
             .dpt-template-card img { max-width: 100%; border-radius: 4px; }
+            .dpt-template-card input[type="radio"] { margin: 5px; }
             .dpt-template-card.dpt-template-placeholder { opacity: 0.8; cursor: pointer; border-style: dashed; }
             .dpt-template-card.dpt-template-placeholder:hover { border-color: #2271b1; background: #f5f5f5; }
             .dpt-placeholder-img { 
@@ -375,18 +376,36 @@ class DigitalScreenSettings {
         }
         
         function selectTemplate(value, element) {
-            // Set the radio button
+            // Find the radio button inside the label
             const radio = element.querySelector('input[type="radio"]');
-            radio.checked = true;
+            if (radio) {
+                radio.checked = true;
+                radio.setAttribute('checked', 'checked');
+            }
             
             // Update visual selection
-            document.querySelectorAll('.dpt-template-card').forEach(function(card) {
-                card.classList.remove('selected');
-            });
+            var cards = document.querySelectorAll('.dpt-template-card');
+            for (var i = 0; i < cards.length; i++) {
+                cards[i].classList.remove('selected');
+            }
             element.classList.add('selected');
             
-            // Log for debugging
-            console.log('Selected template:', value);
+            // Debug
+            console.log('Selected template:', value, 'Radio checked:', radio ? radio.checked : 'no radio');
+            
+            // Force form to include this value
+            var form = document.querySelector('form[name="digitalScreen"]');
+            if (form) {
+                var hiddenInput = form.querySelector('input[name="ds-template-hidden"]');
+                if (!hiddenInput) {
+                    hiddenInput = document.createElement('input');
+                    hiddenInput.type = 'hidden';
+                    hiddenInput.name = 'ds-template-hidden';
+                    form.appendChild(hiddenInput);
+                }
+                hiddenInput.value = value;
+                console.log('Hidden input set to:', value);
+            }
         }
         
         window.updateDisplayMode = function(value) {

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -41,9 +41,13 @@ class DigitalScreenSettings {
             .dpt-form-group { flex: 1; min-width: 200px; }
             .dpt-form-group label { display: block; font-weight: 600; margin-bottom: 6px; color: #444; }
             .dpt-form-group input, .dpt-form-group textarea { 
-                width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;
+                width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;
             }
-            .dpt-form-group textarea { resize: vertical; }
+            .dpt-form-group textarea { 
+                resize: vertical; 
+                min-height: unset;
+                height: auto;
+            }
             .dpt-form-group input:focus, .dpt-form-group textarea:focus { 
                 outline: 2px solid #2271b1; border-color: #2271b1; 
             }
@@ -280,7 +284,7 @@ class DigitalScreenSettings {
             <div class="dpt-section-content">
                 <div class="dpt-form-group">
                     <label>Additional CSS <span class="dpt-hint">(advanced users only)</span></label>
-                    <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }">
+                    <textarea name="ds-additional-css" rows="3" placeholder=".dpt-class { ... }">
                         <?php echo esc_textarea(get_option('ds-additional-css') ?? ''); ?>
                     </textarea>
                 </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -108,6 +108,13 @@ class DigitalScreenSettings {
                         Default Layout
                     </label>
                     <label>
+                        <input type="radio" name="displayMode" value="template" 
+                            <?php echo $templateActive ? 'checked' : ''; ?>>
+                        Activate Template
+                    </label>
+                </div>
+                <div class="dpt-option-group">
+                    <label>
                         <input type="radio" name="displayMode" value="quran" 
                             <?php echo get_option('quran-chbox') === 'displayQuran' ? 'checked' : ''; ?>>
                         Display Quran Verse
@@ -116,11 +123,6 @@ class DigitalScreenSettings {
                         <input type="radio" name="displayMode" value="slider" 
                             <?php echo $sliderActive ? 'checked' : ''; ?>>
                         Activate Slider
-                    </label>
-                    <label>
-                        <input type="checkbox" id="template-chbox" 
-                            <?php echo $templateActive ? 'checked' : ''; ?>>
-                        Activate Template
                     </label>
                 </div>
                 <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" value="<?php echo esc_attr(get_option('quran-chbox') ?? ''); ?>">
@@ -326,48 +328,36 @@ class DigitalScreenSettings {
                 const quranInput = $('#quran-chbox-hidden');
                 const sliderInput = $('#slider-chbox-hidden');
                 const templateInput = $('#template-chbox-hidden');
-                const templateCheckbox = $('#template-chbox');
                 
                 if (value === 'slider') {
                     quranInput.val('');
                     sliderInput.val('slider');
                     templateInput.val('');
-                    templateCheckbox.prop('checked', false);
                     sliderSection.removeClass('hidden').addClass('active');
                     templateSection.removeClass('active').addClass('hidden');
                 } else if (value === 'quran') {
                     sliderInput.val('');
                     templateInput.val('');
-                    templateCheckbox.prop('checked', false);
                     quranInput.val('displayQuran');
                     sliderSection.removeClass('active').addClass('hidden');
                     templateSection.removeClass('active').addClass('hidden');
+                } else if (value === 'template') {
+                    sliderInput.val('');
+                    quranInput.val('');
+                    templateInput.val('template');
+                    sliderSection.removeClass('active').addClass('hidden');
+                    templateSection.removeClass('hidden').addClass('active');
                 } else if (value === 'default') {
                     sliderInput.val('');
                     templateInput.val('');
-                    templateCheckbox.prop('checked', false);
                     quranInput.val('');
                     sliderSection.removeClass('active').addClass('hidden');
                     templateSection.removeClass('active').addClass('hidden');
                 }
             });
             
-            // Template checkbox toggle
-            $('#template-chbox').on('change', function() {
-                const templateSection = $('#dpt-template-section');
-                const templateInput = $('#template-chbox-hidden');
-                
-                if ($(this).is(':checked')) {
-                    templateInput.val('template');
-                    templateSection.removeClass('hidden').addClass('active');
-                } else {
-                    templateInput.val('');
-                    templateSection.removeClass('active').addClass('hidden');
-                }
-            });
-            
             // Initialize template section visibility on load
-            if (!$('#template-chbox').is(':checked')) {
+            if ($('input[name="displayMode"]:checked').val() !== 'template') {
                 $('#dpt-template-section').addClass('hidden');
             }
             

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -245,7 +245,7 @@ class DigitalScreenSettings {
                     <div class="dpt-slider-row">
                         <div class="dpt-slider-fields">
                             <div class="dpt-slider-input-row">
-                                <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">🖼️ Select from Media</button>
+                                <button type="button" class="dpt-media-btn" data-input="slider<?php echo $i; ?>">📁 Media Library</button>
                                 <input type="text" placeholder="Image URL or message" name="slider<?php echo $i; ?>" 
                                     value="<?php echo esc_attr(get_option("slider$i") ?? ''); ?>">
                             </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -284,9 +284,7 @@ class DigitalScreenSettings {
             <div class="dpt-section-content">
                 <div class="dpt-form-group">
                     <label>Additional CSS <span class="dpt-hint">(advanced users only)</span></label>
-                    <textarea name="ds-additional-css" rows="3" placeholder=".dpt-class { ... }">
-                        <?php echo esc_textarea(get_option('ds-additional-css') ?? ''); ?>
-                    </textarea>
+                    <textarea name="ds-additional-css" rows="3" placeholder=".dpt-class { ... }"><?php echo get_option('ds-additional-css'); ?></textarea>
                 </div>
             </div>
         </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -43,9 +43,11 @@ class DigitalScreenSettings {
             .dpt-form-group input, .dpt-form-group textarea { 
                 width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;
             }
+            .dpt-form-group textarea { max-height: 120px; overflow-y: auto; resize: vertical; }
             .dpt-form-group input:focus, .dpt-form-group textarea:focus { 
                 outline: 2px solid #2271b1; border-color: #2271b1; 
             }
+            .dpt-section textarea { min-height: 100px; }
             .dpt-form-group-wide { flex: 2; }
             .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
             

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -43,11 +43,10 @@ class DigitalScreenSettings {
             .dpt-form-group input, .dpt-form-group textarea { 
                 width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;
             }
-            .dpt-form-group textarea { max-height: 120px; overflow-y: auto; resize: vertical; }
+            .dpt-form-group textarea { resize: vertical; }
             .dpt-form-group input:focus, .dpt-form-group textarea:focus { 
                 outline: 2px solid #2271b1; border-color: #2271b1; 
             }
-            .dpt-section textarea { min-height: 100px; }
             .dpt-form-group-wide { flex: 2; }
             .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
             

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -282,7 +282,7 @@ class DigitalScreenSettings {
                 <div class="dpt-form-group">
                     <label>Additional CSS <span class="dpt-hint">(advanced users only)</span></label>
                     <textarea name="ds-additional-css" rows="5" placeholder=".dpt-class { ... }">
-                        <?php echo esc_textarea(get_option('ds-additional-css') ?? 'x'); ?>asdfa
+                        <?php echo esc_textarea(get_option('ds-additional-css') ?? ''); ?>
                     </textarea>
                 </div>
             </div>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -303,7 +303,7 @@ class DigitalScreenSettings {
                             <input type="radio" name="ds-template" value="custom" disabled>
                             <strong>Add your template here</strong>
                         </div>
-                        <small><a href="mailto:mmrs151@gmail.com?subject=Custom Template Design">Let's discuss</a></small>
+                        <small><a href="<?php echo esc_url( 'mailto:mmrs151@gmail.com?subject=' . rawurlencode( 'Custom Template Design' ) ); ?>"><?php echo esc_html( "Let's discuss" ); ?></a></small>
                     </label>
                 </div>
             </div>
@@ -420,9 +420,11 @@ class DigitalScreenSettings {
                 frame.open();
             });
             
-            // Template selection
-            $('.dpt-template-card').on('click', function() {
-                $(this).find('input[type="radio"]').prop('checked', true);
+// Template selection - only for enabled radios (skip placeholder)
+            $('.dpt-template-card:not(.dpt-template-placeholder)').on('click', function(e) {
+                e.preventDefault();
+                const radio = $(this).find('input[type="radio"]');
+                radio.prop('checked', true).trigger('change');
                 $('.dpt-template-card').removeClass('selected');
                 $(this).addClass('selected');
             });

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -13,6 +13,7 @@ for ($i = 1; $i <= 11; $i++) {
     }
 }
 $displayCount = max(1, min($existingSliders, $maxSliders));
+$isSliderActive = get_option("slider-chbox") === 'slider';
 ?>
 <style>
 .dpt-ds-accordion { margin-bottom: 10px; }
@@ -25,6 +26,7 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
 .dpt-ds-accordion.active .accordion-header:after { transform: rotate(180deg); }
 .dpt-ds-accordion .accordion-content { display: none; padding: 15px; border: 1px solid #ddd; border-top: none; }
 .dpt-ds-accordion.active .accordion-content { display: block; }
+.dpt-ds-accordion.dpt-hidden { display: none; }
 
 .dpt-ds-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 15px; }
 .dpt-ds-field { display: flex; flex-direction: column; gap: 5px; }
@@ -106,15 +108,33 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
     
     <div id="dpt-ds-accordions">
         
+        <!-- Template Selection (at top, optional) -->
+        <div class="dpt-ds-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
+            <div class="accordion-content">
+                <div class="dpt-template-grid">
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
+                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
+                    </label>
+                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
+                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
+                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
+                    </label>
+                    <label class="dpt-template-card" style="opacity: 0.6;">
+                        <div style="padding: 40px 10px;">Coming Soon</div>
+                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
+                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
+                    </label>
+                </div>
+            </div>
+        </div>
+
         <!-- General Settings -->
         <div class="dpt-ds-accordion active">
             <div class="accordion-header" onclick="toggleDsAccordion(this)">⚙️ General Settings</div>
             <div class="accordion-content">
                 <div class="dpt-exclusive-group">
-                    <label>
-                        <input type="radio" name="displayMode" value="none" <?php echo (get_option("quran-chbox") !== 'displayQuran' && get_option("slider-chbox") !== 'slider') ? 'checked' : ''; ?>>
-                        None
-                    </label>
                     <label>
                         <input type="radio" name="displayMode" value="quran" <?php echo (get_option("quran-chbox") === 'displayQuran') ? 'checked' : ''; ?>>
                         Display Quran Verse
@@ -156,9 +176,9 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
             </div>
         </div>
 
-        <!-- Slider Settings + Image Sliders (merged) -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider / Quran Settings</div>
+        <!-- Slider Settings (only visible when slider is active) -->
+        <div class="dpt-ds-accordion <?php echo $isSliderActive ? 'active' : ''; ?>" id="dpt-slider-accordion">
+            <div class="accordion-header" onclick="toggleDsAccordion(this)">🖼️ Slider Settings</div>
             <div class="accordion-content">
                 <div class="dpt-ds-row" style="margin-bottom: 20px;">
                     <div class="dpt-ds-field">
@@ -213,7 +233,7 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
             </div>
         </div>
 
-        <!-- Instructions -->
+        <!-- How to Use (last) -->
         <div class="dpt-ds-accordion">
             <div class="accordion-header" onclick="toggleDsAccordion(this)">❓ How to Use</div>
             <div class="accordion-content">
@@ -238,28 +258,6 @@ $displayCount = max(1, min($existingSliders, $maxSliders));
             </div>
         </div>
 
-        <!-- Template Selection (at bottom, optional) -->
-        <div class="dpt-ds-accordion">
-            <div class="accordion-header" onclick="toggleDsAccordion(this)">🎨 Template Selection (Optional)</div>
-            <div class="accordion-content">
-                <div class="dpt-template-grid">
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'eict') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/EICT.png', __FILE__)?>" alt="EICT">
-                        <div><input type="radio" name="ds-template" value="eict" <?php if(get_option("dsTemplate") === 'eict'){ echo 'checked'; } ?>> <strong>Edgware ICT</strong></div>
-                    </label>
-                    <label class="dpt-template-card <?php echo (get_option("dsTemplate") === 'usman') ? 'selected' : ''; ?>">
-                        <img src="<?php echo plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__)?>" alt="Usman">
-                        <div><input type="radio" name="ds-template" value="usman" <?php if(get_option("dsTemplate") === 'usman'){ echo 'checked'; } ?>> <strong>Masjid-E-Usman</strong></div>
-                    </label>
-                    <label class="dpt-template-card" style="opacity: 0.6;">
-                        <div style="padding: 40px 10px;">Coming Soon</div>
-                        <div><input type="radio" disabled> <strong>Your Design</strong></div>
-                        <small><a href="mailto:mmrs151@gmail.com">Request quote</a></small>
-                    </label>
-                </div>
-            </div>
-        </div>
-
     </div>
 
     <div style="margin-top: 20px;">
@@ -277,15 +275,18 @@ jQuery(document).ready(function($) {
     // Handle exclusive radio buttons
     $('input[name="displayMode"]').on('change', function() {
         var value = $(this).val();
-        if (value === 'quran') {
-            $('input[name="quran-chbox"]').val('displayQuran');
-            $('input[name="slider-chbox"]').val('');
-        } else if (value === 'slider') {
+        var $sliderAccordion = $('#dpt-slider-accordion');
+        
+        if (value === 'slider') {
             $('input[name="slider-chbox"]').val('slider');
             $('input[name="quran-chbox"]').val('');
-        } else {
-            $('input[name="quran-chbox"]').val('');
+            $sliderAccordion.removeClass('dpt-hidden');
+            $sliderAccordion.addClass('active');
+        } else if (value === 'quran') {
+            $('input[name="quran-chbox"]').val('displayQuran');
             $('input[name="slider-chbox"]').val('');
+            $sliderAccordion.removeClass('active');
+            $sliderAccordion.addClass('dpt-hidden');
         }
     });
     

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -24,16 +24,18 @@ class DigitalScreenSettings {
     }
     
     private function loadSettings(): void {
+        $savedTemplate = get_option('dsTemplate') ?? '';
+        
         $this->templates = [
             'eict' => [
                 'name' => 'Edgware ICT',
                 'image' => plugins_url('../../Assets/images/EICT.png', __FILE__),
-                'value' => get_option('dsTemplate')
+                'isSelected' => $savedTemplate === 'eict'
             ],
             'usman' => [
                 'name' => 'Masjid-E-Usman',
                 'image' => plugins_url('../../Assets/images/masjid-e-usman.jpeg', __FILE__),
-                'value' => get_option('dsTemplate')
+                'isSelected' => $savedTemplate === 'usman'
             ]
         ];
         
@@ -288,11 +290,11 @@ class DigitalScreenSettings {
             <div class="dpt-section-content">
                 <div class="dpt-template-grid">
                     <?php foreach ($this->templates as $key => $template): ?>
-                    <label class="dpt-template-card <?php echo $template['value'] === $key ? 'selected' : ''; ?>">
+                    <label class="dpt-template-card <?php echo $template['isSelected'] ? 'selected' : ''; ?>">
                         <img src="<?php echo esc_url($template['image']); ?>" alt="<?php echo esc_attr($template['name']); ?>">
                         <div>
                             <input type="radio" name="ds-template" value="<?php echo esc_attr($key); ?>"
-                                <?php checked($template['value'], $key); ?>>
+                                <?php checked($template['isSelected']); ?>>
                             <strong><?php echo esc_html($template['name']); ?></strong>
                         </div>
                     </label>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -46,10 +46,8 @@ class DigitalScreenSettings {
             .dpt-form-group input:focus, .dpt-form-group textarea:focus { 
                 outline: 2px solid #2271b1; border-color: #2271b1; 
             }
-            .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
-            
-            .dpt-form-group { flex: 1; }
             .dpt-form-group-wide { flex: 2; }
+            .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
             
             .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; align-items: center; }
             .dpt-option-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -114,14 +114,17 @@ $isSliderActive = get_option("slider-chbox") === 'slider';
             <div class="accordion-content">
                 <div class="dpt-exclusive-group">
                     <label>
-                        <input type="radio" name="displayMode" value="quran" <?php echo (get_option("quran-chbox") === 'displayQuran') ? 'checked' : ''; ?>>
+                        <input type="radio" name="displayMode" value="quran" <?php echo (get_option("quran-chbox") === 'displayQuran') ? 'checked' : ''; ?> onchange="updateDisplayMode(this.value)">
                         Display Quran Verse
                     </label>
                     <label>
-                        <input type="radio" name="displayMode" value="slider" <?php echo (get_option("slider-chbox") === 'slider') ? 'checked' : ''; ?>>
+                        <input type="radio" name="displayMode" value="slider" <?php echo (get_option("slider-chbox") === 'slider') ? 'checked' : ''; ?> onchange="updateDisplayMode(this.value)">
                         Activate Slider
                     </label>
                 </div>
+                <!-- Hidden inputs to store actual option values -->
+                <input type="hidden" name="quran-chbox" id="quran-chbox-hidden" value="<?php echo esc_attr(get_option("quran-chbox")); ?>">
+                <input type="hidden" name="slider-chbox" id="slider-chbox-hidden" value="<?php echo esc_attr(get_option("slider-chbox")); ?>">
                 <div class="dpt-ds-field" style="margin-top: 15px;">
                     <label>Fading Messages <span class="hint">(separated by full stop)</span></label>
                     <textarea name="ds-fading-msg" rows="3"><?php echo esc_html(stripslashes(get_option("ds-fading-msg")) )?></textarea>
@@ -266,23 +269,20 @@ function toggleDsAccordion(header) {
 }
 
 jQuery(document).ready(function($) {
-    // Handle exclusive radio buttons
-    $('input[name="displayMode"]').on('change', function() {
-        var value = $(this).val();
-        var $sliderAccordion = $('#dpt-slider-accordion');
-        
+    // Handle exclusive display mode selection
+    window.updateDisplayMode = function(value) {
         if (value === 'slider') {
-            $('input[name="slider-chbox"]').val('slider');
-            $('input[name="quran-chbox"]').val('');
-            $sliderAccordion.removeClass('dpt-hidden');
-            $sliderAccordion.addClass('active');
+            $('#quran-chbox-hidden').val('');
+            $('#slider-chbox-hidden').val('slider');
+            $('#dpt-slider-accordion').removeClass('dpt-hidden');
+            $('#dpt-slider-accordion').addClass('active');
         } else if (value === 'quran') {
-            $('input[name="quran-chbox"]').val('displayQuran');
-            $('input[name="slider-chbox"]').val('');
-            $sliderAccordion.removeClass('active');
-            $sliderAccordion.addClass('dpt-hidden');
+            $('#slider-chbox-hidden').val('');
+            $('#quran-chbox-hidden').val('displayQuran');
+            $('#dpt-slider-accordion').removeClass('active');
+            $('#dpt-slider-accordion').addClass('dpt-hidden');
         }
-    });
+    };
     
     // Add Another Slider button
     $('#dpt-add-slider').on('click', function() {

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -48,8 +48,9 @@ class DigitalScreenSettings {
             }
             .dpt-hint { font-weight: normal; color: #666; font-size: 12px; }
             
-            .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; }
+            .dpt-option-group { display: flex; gap: 20px; margin-bottom: 20px; flex-wrap: wrap; align-items: center; }
             .dpt-option-group label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+            .dpt-option-group .dpt-separator { color: #999; font-weight: bold; margin: 0 10px; }
             
             .dpt-slider-card {
                 border: 1px solid #ddd; border-radius: 8px; padding: 15px; margin-bottom: 12px;
@@ -112,8 +113,7 @@ class DigitalScreenSettings {
                             <?php echo $templateActive ? 'checked' : ''; ?>>
                         Activate Template
                     </label>
-                </div>
-                <div class="dpt-option-group">
+                    <span class="dpt-separator">|</span>
                     <label>
                         <input type="radio" name="displayMode" value="quran" 
                             <?php echo get_option('quran-chbox') === 'displayQuran' ? 'checked' : ''; ?>>

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -379,9 +379,20 @@ class DigitalScreenSettings {
                 }
             });
             
-            // Initialize template section visibility on load
-            if ($('input[name="displayMode"]:checked').val() !== 'template') {
-                $('#dpt-template-section').addClass('hidden');
+            // Initialize section visibility on load
+            const displayMode = $('input[name="displayMode"]:checked').val();
+            const displayModeAlt = $('input[name="displayModeAlt"]:checked').val();
+            
+            if (displayMode === 'template') {
+                $('#dpt-template-section').removeClass('hidden').addClass('active');
+            } else {
+                $('#dpt-template-section').addClass('hidden').removeClass('active');
+            }
+            
+            if (displayModeAlt === 'slider') {
+                $('#dpt-slider-section').removeClass('hidden').addClass('active');
+            } else {
+                $('#dpt-slider-section').addClass('hidden').removeClass('active');
             }
             
             // Sync hidden inputs with checked radio on page load

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -149,7 +149,7 @@ if (! empty($_POST['digitalScreen']) && check_admin_referer( 'digitalScreen' )) 
         'ds-scroll-speed' => sanitize_text_field($_POST['ds-scroll-speed']),
         'ds-blink-text' => sanitize_text_field($_POST['ds-blink-text']),
         'ds-fading-msg' => sanitize_text_field($_POST['ds-fading-msg']),
-        'ds-additional-css' => sanitize_textarea_field($_POST['ds-additional-css'] ?? ''),
+        'ds-additional-css' => trim($_POST['ds-additional-css'] ?? ''),
         'template-chbox' => sanitize_text_field($_POST['template-chbox'] ?? ''),
         'quran-chbox' => sanitize_text_field($_POST['quran-chbox'] ?? ''),
         'slider-chbox' => sanitize_text_field($_POST['slider-chbox'] ?? ''),

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -154,7 +154,7 @@ if (! empty($_POST['digitalScreen']) && check_admin_referer( 'digitalScreen' )) 
         'quran-chbox' => sanitize_text_field($_POST['quran-chbox'] ?? ''),
         'slider-chbox' => sanitize_text_field($_POST['slider-chbox'] ?? ''),
         'nextPrayerSlide' => sanitize_text_field($_POST['nextPrayerSlide']),
-        'ds-template' => sanitize_text_field($_POST['ds-template'] ?? ''),
+        'ds-template' => sanitize_text_field($_POST['ds-template-hidden'] ?? $_POST['ds-template'] ?? ''),
         'transitionEffect' => sanitize_text_field($_POST['transitionEffect'] ?? ''),
         'transitionSpeed' => sanitize_text_field($_POST['transitionSpeed']),
         'slider1' => sanitize_text_field($_POST['slider1']),

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -143,10 +143,6 @@ if (! empty($_POST['themeSettings']) && check_admin_referer( 'themeSettings' )) 
 }
 
 if (! empty($_POST['digitalScreen']) && check_admin_referer( 'digitalScreen' )) {
-    // DEBUG: Log ds-template value
-    error_log('DEBUG: ds-template POST value: ' . print_r($_POST['ds-template'], true));
-    error_log('DEBUG: ds-template-hidden POST value: ' . print_r($_POST['ds-template-hidden'] ?? 'NOT SET', true));
-    
     $data = [
         'ds-logo' => sanitize_text_field($_POST['ds-logo']),
         'ds-scroll-text' => sanitize_text_field($_POST['ds-scroll-text']),

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -143,6 +143,10 @@ if (! empty($_POST['themeSettings']) && check_admin_referer( 'themeSettings' )) 
 }
 
 if (! empty($_POST['digitalScreen']) && check_admin_referer( 'digitalScreen' )) {
+    // DEBUG: Log ds-template value
+    error_log('DEBUG: ds-template POST value: ' . print_r($_POST['ds-template'], true));
+    error_log('DEBUG: ds-template-hidden POST value: ' . print_r($_POST['ds-template-hidden'] ?? 'NOT SET', true));
+    
     $data = [
         'ds-logo' => sanitize_text_field($_POST['ds-logo']),
         'ds-scroll-text' => sanitize_text_field($_POST['ds-scroll-text']),

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -149,7 +149,7 @@ if (! empty($_POST['digitalScreen']) && check_admin_referer( 'digitalScreen' )) 
         'ds-scroll-speed' => sanitize_text_field($_POST['ds-scroll-speed']),
         'ds-blink-text' => sanitize_text_field($_POST['ds-blink-text']),
         'ds-fading-msg' => sanitize_text_field($_POST['ds-fading-msg']),
-        'ds-additional-css' => sanitize_text_field($_POST['ds-additional-css']),
+        'ds-additional-css' => sanitize_textarea_field($_POST['ds-additional-css'] ?? ''),
         'template-chbox' => sanitize_text_field($_POST['template-chbox'] ?? ''),
         'quran-chbox' => sanitize_text_field($_POST['quran-chbox'] ?? ''),
         'slider-chbox' => sanitize_text_field($_POST['slider-chbox'] ?? ''),


### PR DESCRIPTION
## Summary
- Add media gallery button for selecting slider images via WordPress media library
- Add dynamic slider management (show 1 initially, add more up to 7)
- Add template selection with checkbox toggle (Activate Template)
- Refactor DigitalScreen.php with OOP approach and proper method separation
- Fix template display logic to require both checkbox AND template selection
- Fix carousel issues in EICT template (remove duplicate active item, update CSS)
- Update CSS for carousel images to scale properly

## Changes
- Views/Tabs/DigitalScreen.php: Refactored settings page with cleaner UI
- Models/DigitalScreen.php: Added hasSliderImages(), slidesOnly param
- Models/design/eict.php & usman.php: Updated for slider images
- Assets/css: Updated carousel image styling