### PR TITLE
fix: zawal/ishraq display and highlighting improvements

### DIFF
--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -266,7 +266,13 @@ class DPTHelper
                 }
                 $prayer = array_search( $jamah, $row ); 
                 $prayer = explode( '_', $prayer);
-                return $prayer[0]; 
+                $nextPrayer = $prayer[0];
+                
+                // If today is Friday and next is Zuhr, return Jumuah
+                if ($this->todayIsFriday() && $nextPrayer == 'zuhr') {
+                    return 'jumuah';
+                }
+                return $nextPrayer; 
             }
         }
     }

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -246,8 +246,8 @@ class DPTHelper
             $nowTs = strtotime($now);
             $ishraqTs = strtotime($ishraqTime);
             
-            // After ishraq starts but before zuhr, next prayer is zuhr
-            if ($nowTs >= $ishraqTs && $nowTs < $zuhrTs) {
+            // Between ishraq and zuhr, next prayer is zuhr
+            if ($nowTs > $ishraqTs && $nowTs < $zuhrTs) {
                 return 'zuhr';
             }
         }
@@ -280,16 +280,15 @@ class DPTHelper
 
     public function getSunriseOrZawalOrIshraq($row)
     {
-        $nextPrayer = $this->getNextPrayer($row);
         $ishraqMins = get_option('ishraq');
 
-        // If ishraq is next, show ishraq
-        if ($ishraqMins && $ishraqMins != '0' && $nextPrayer == 'ishraq') {
+        // If ishraq time is next (between fajr and ishraq), show ishraq - check FIRST
+        if ($ishraqMins && $ishraqMins != '0' && $this->isIshraqTimeNext($row)) {
             return 'ishraq';
         }
 
-        // If zawal is enabled and zuhr is next, show zawal
-        if (get_option('zawal') && $nextPrayer == 'zuhr') {
+        // If zawal is enabled and zawal time is next (between sunrise and zuhr), show zawal
+        if (get_option('zawal') && $this->isZawalTimeNext($row)) {
             return 'zawal';
         }
 

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -281,6 +281,7 @@ class DPTHelper
     public function getSunriseOrZawalOrIshraq($row)
     {
         $ishraqMins = get_option('ishraq');
+        $zawalEnabled = get_option('zawal');
 
         // If ishraq time is next (between fajr and ishraq), show ishraq - check FIRST
         if ($ishraqMins && $ishraqMins != '0' && $this->isIshraqTimeNext($row)) {
@@ -288,7 +289,7 @@ class DPTHelper
         }
 
         // If zawal is enabled and zawal time is next (between sunrise and zuhr), show zawal
-        if (get_option('zawal') && $this->isZawalTimeNext($row)) {
+        if ($zawalEnabled && $this->isZawalTimeNext($row)) {
             return 'zawal';
         }
 
@@ -365,7 +366,9 @@ class DPTHelper
 
     public function isZawalTimeNext($row)
     {
+        $nowStr = user_current_time('H:i');
         $now = new DateTime();
+        $now->setTimestamp(strtotime($nowStr));
         
         $ishraqMins = get_option('ishraq');
         

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -208,7 +208,8 @@ class DPTHelper
         }
 
         // If zawal time is next, highlight zuhr row (not sunrise row)
-        if ($this->isZawalTimeNext($row) && $prayerName == 'zuhr') {
+        // Do not highlight Zuhr for zawal on Fridays (Jumuah handling takes precedence)
+        if ($this->isZawalTimeNext($row) && $prayerName == 'zuhr' && ! $this->todayIsFriday()) {
             return 'nextPrayer';
         }
         

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -369,13 +369,21 @@ class DPTHelper
         $now = new DateTime();
         $now->setTimestamp(strtotime($userTime));
 
-        $sunrise = new DateTime();
-        $sunrise->setTimestamp(strtotime($row['sunrise']));
+        $ishraqMins = get_option('ishraq');
+        
+        // If ishraq is enabled, use ishraq time as start of zawal window
+        $zawalStart = $row['sunrise'];
+        if ($ishraqMins && $ishraqMins != '0') {
+            $zawalStart = $this->getIshraqTime($row['sunrise']);
+        }
+
+        $zawalStartDt = new DateTime();
+        $zawalStartDt->setTimestamp(strtotime($zawalStart));
 
         $zuhr = new DateTime();
         $zuhr->setTimestamp(strtotime($row['zuhr_begins']));
 
-        if ($now > $sunrise && $now < $zuhr) { 
+        if ($now > $zawalStartDt && $now < $zuhr) { 
             return true;
         }
         return false;

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -366,24 +366,22 @@ class DPTHelper
 
     public function isZawalTimeNext($row)
     {
-        $nowStr = user_current_time('H:i');
-        $now = new DateTime();
-        $now->setTimestamp(strtotime($nowStr));
-        
         $ishraqMins = get_option('ishraq');
         
-        // If ishraq is enabled, use ishraq time as start of zawal window
+        // Determine zawal start time (sunrise or ishraq if enabled)
         $zawalStart = $row['sunrise'];
         if ($ishraqMins && $ishraqMins != '0') {
             $zawalStart = $this->getIshraqTime($row['sunrise']);
         }
-
-        $zawalStartDt = new DateTime($zawalStart);
-        $zuhr = new DateTime($row['zuhr_begins']);
-
-        if ($now > $zawalStartDt && $now < $zuhr) { 
-            return true;
-        }
-        return false;
+        
+        $zuhrBegins = $row['zuhr_begins'];
+        
+        // Use strtotime for consistent comparison (same as isIshraqTimeNext)
+        $nowStr = user_current_time('H:i');
+        $nowTs = strtotime($nowStr);
+        $zawalStartTs = strtotime($zawalStart);
+        $zuhrTs = strtotime($zuhrBegins);
+        
+        return $nowTs >= $zawalStartTs && $nowTs < $zuhrTs;
     }
 }

--- a/Models/DPTHelper.php
+++ b/Models/DPTHelper.php
@@ -365,10 +365,8 @@ class DPTHelper
 
     public function isZawalTimeNext($row)
     {
-        $userTime = user_current_time( 'H:i');
         $now = new DateTime();
-        $now->setTimestamp(strtotime($userTime));
-
+        
         $ishraqMins = get_option('ishraq');
         
         // If ishraq is enabled, use ishraq time as start of zawal window
@@ -377,11 +375,8 @@ class DPTHelper
             $zawalStart = $this->getIshraqTime($row['sunrise']);
         }
 
-        $zawalStartDt = new DateTime();
-        $zawalStartDt->setTimestamp(strtotime($zawalStart));
-
-        $zuhr = new DateTime();
-        $zuhr->setTimestamp(strtotime($row['zuhr_begins']));
+        $zawalStartDt = new DateTime($zawalStart);
+        $zuhr = new DateTime($row['zuhr_begins']);
 
         if ($now > $zawalStartDt && $now < $zuhr) { 
             return true;

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -261,11 +261,9 @@ class DailyTimetablePrinter extends TimetablePrinter
                 $shouldHighlight = true;
             }
             // On Friday, don't highlight Zuhr (Jumuah row is highlighted instead)
-            $isFriday = $this->todayIsFriday();
-            if ($isFriday && $key == 'zuhr') {
+            if ($this->todayIsFriday() && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
-            error_log("DEBUG printTableHeading: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");
             $class = $shouldHighlight ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
@@ -467,7 +465,6 @@ class DailyTimetablePrinter extends TimetablePrinter
             if ($isFriday && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
-            error_log("DEBUG printVerticalRow: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");
             $class = $shouldHighlight ? 'highlight' : '';
             $highlightForJamah = $shouldHighlight ? 'highlight' : '';
 

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -260,6 +260,10 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
+            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = false;
+            }
             $class = $shouldHighlight ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
@@ -300,6 +304,10 @@ class DailyTimetablePrinter extends TimetablePrinter
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
+            }
+            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = false;
             }
 
             $class = $shouldHighlight ? "class='highlight'" : '';
@@ -345,6 +353,10 @@ class DailyTimetablePrinter extends TimetablePrinter
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
+            }
+            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($onFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = false;
             }
             
             $class = $shouldHighlight ? 'class=highlight' : 'class=jamah';
@@ -412,6 +424,7 @@ class DailyTimetablePrinter extends TimetablePrinter
     {
         $trs = '';
         $nextPrayer = $this->getNextPrayer( $row );
+        $isFriday = $this->todayIsFriday();
 
         $localPrayerNames = $this->localPrayerNames;
         
@@ -448,6 +461,10 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
+            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($isFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = false;
+            }
             $class = $shouldHighlight ? 'highlight' : '';
             $highlightForJamah = $shouldHighlight ? 'highlight' : '';
 
@@ -472,7 +489,6 @@ class DailyTimetablePrinter extends TimetablePrinter
         // and current time is before the last configured Jumuah time (on Fridays).
         $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
         $showJumuah = false;
-        $isFriday = $this->todayIsFriday();
         if (! empty($jumuahOptions) && $isFriday) {
             $nowTs = strtotime( user_current_time('H:i') );
             $lastJumuahTs = max( array_map('strtotime', $jumuahOptions) );

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -42,7 +42,8 @@ class DailyTimetablePrinter extends TimetablePrinter
                   .$this->printJamahTime($row, false).
             '</tr>';
 
-        if ( get_option('jumuah1') && ! $this->todayIsFriday() ) {
+            $nextPrayer = $this->getNextPrayer( $row );
+        if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) {
             $table .= '<tr>
                             <th class="tableHeading">' . stripslashes($this->getLocalHeaders()['jumuah']) . '</th>
                             <td colspan="6" class="jamah">' . $this->getJumuahTimesArray() . '</td>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -216,10 +216,6 @@ class DailyTimetablePrinter extends TimetablePrinter
 
         $localPrayerNames = $this->localPrayerNames;
         
-        if (get_option('zawal')) {
-            $localPrayerNames = $this->toggleSunriseZawal($row, $localPrayerNames);
-        }
-        
         // Handle ishraq - merge into sunrise row, show only sunrise
         $ishraqMins = get_option('ishraq');
         if ($ishraqMins && $ishraqMins != '0' && isset($localPrayerNames['ishraq'])) {
@@ -229,6 +225,16 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         if (isset($localPrayerNames['ishraq'])) {
             unset($localPrayerNames['ishraq']);
+        }
+        
+        // Handle zawal - show zawal instead of sunrise if zawal time is next
+        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
+        }
+        
+        // Remove zawal - never show as separate prayer name
+        if (isset($localPrayerNames['zawal'])) {
+            unset($localPrayerNames['zawal']);
         }
         
         foreach ($localPrayerNames as $key=>$prayerName) {
@@ -276,6 +282,11 @@ class DailyTimetablePrinter extends TimetablePrinter
             unset($azanTimings['ishraq']);
         }
 
+        // Handle zawal - show zawal time instead of sunrise if zawal time is next
+        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            $azanTimings['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
+        }
+
         // Remove zawal - never show as separate time
         if (isset($azanTimings['zawal'])) {
             unset($azanTimings['zawal']);
@@ -319,6 +330,11 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         if (isset($jamahTimes['ishraq'])) {
             unset($jamahTimes['ishraq']);
+        }
+
+        // Handle zawal - show zawal time instead of sunrise if zawal time is next
+        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            $jamahTimes['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
         }
         
         if (! $isSunrise) {
@@ -422,6 +438,12 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         if (isset($localPrayerNames['ishraq'])) {
             unset($localPrayerNames['ishraq']);
+        }
+        
+        // Handle zawal - show zawal instead of sunrise if zawal time is next
+        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
+            $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
         }
         
         // Remove zawal - never show as separate prayer name

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -164,7 +164,7 @@ class DailyTimetablePrinter extends TimetablePrinter
         if (! $row['hideTimeRemaining']) {
             $nextIqamah = $isAzanOnly == true ? '' : $this->getNextIqamahTime($row);
         }
-        $colspan = 7;
+        $colspan = 8;
         $ramadanTds = '<td></td>';
 
         $ramadan = '';
@@ -233,11 +233,12 @@ class DailyTimetablePrinter extends TimetablePrinter
         foreach ($localPrayerNames as $key=>$prayerName) {
             // On Friday, Zuhr stays as "Zuhr" but NOT highlighted
             $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
-            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
+            $shouldHighlight = (!$isFridayAndZuhr && $nextPrayer == $key);
+            $class = $shouldHighlight ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
         
-        // Add Jumuah column on Friday at the END (after Isha)
+        // Add Jumuah column on Friday at the END (after Isha) - HIGHLIGHT IT
         if ($this->todayIsFriday() && get_option('jumuah1')) {
             $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -260,9 +260,9 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
+            // On Friday, don't highlight Zuhr (Jumuah row is highlighted instead)
             $isFriday = $this->todayIsFriday();
-            if ($isFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+            if ($isFriday && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
             error_log("DEBUG printTableHeading: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");
@@ -307,8 +307,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+            // On Friday, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($this->todayIsFriday() && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
 
@@ -356,8 +356,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
-            if ($onFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+            // On Friday, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($onFriday && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
             
@@ -463,8 +463,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
-            if ($isFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+            // On Friday, don't highlight Zuhr (Jumuah row is highlighted instead)
+            if ($isFriday && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
             error_log("DEBUG printVerticalRow: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -341,6 +341,12 @@ class DailyTimetablePrinter extends TimetablePrinter
         foreach ($jamahTimes as $key => $azan) {
             $class = $nextPrayer == $key ? 'class=highlight' : 'class=jamah';
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</th>";
+            
+            // On Friday, add Jumuah column after Zuhr
+            if ($this->todayIsFriday() && $key == 'zuhr' && get_option('jumuah1')) {
+                $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
+                $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</th>";
+            }
         }
 
         return $tds;
@@ -455,7 +461,8 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         if ( get_option('jumuah1') && $display != 'azan' ) {
-            $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
+            $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+            $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>
                             <th class="prayerName ' . $jumuahClass . '"><span>' . stripslashes($this->getLocalHeaders()['jumuah']) . '</span></th>
                             <td colspan="2" class="jamah ' . $jumuahClass . '">' . $this->getJumuahTimesArray() . '</td>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -300,7 +300,7 @@ class DailyTimetablePrinter extends TimetablePrinter
         // On Friday, add Jumuah column at the END (after Isha) for Azan
         if ($this->todayIsFriday() && get_option('jumuah1')) {
             $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : '';
-            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
+            $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
         }
 
         return $tds;
@@ -348,7 +348,7 @@ class DailyTimetablePrinter extends TimetablePrinter
         // On Friday, add Jumuah column at the END (after Isha)
         if ($this->todayIsFriday() && get_option('jumuah1')) {
             $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
-            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
+            $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
         }
 
         return $tds;

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -231,8 +231,22 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         
         foreach ($localPrayerNames as $key=>$prayerName) {
+            // On Friday, replace Zuhr with Jumuah in display
+            if ($this->todayIsFriday() && $key == 'zuhr') {
+                $prayerName = $this->localHeaders['jumuah'] ?? 'Jumuah';
+            }
             $class = $nextPrayer == $key ? 'highlight' : '';
+            // On Friday, highlight Jumuah instead of Zuhr
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $class = 'highlight';
+            }
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
+        }
+        
+        // Add Jumuah column on Friday
+        if ($this->todayIsFriday() && get_option('jumuah1')) {
+            $jumuahClass = $nextPrayer == 'jumuah' ? 'highlight' : '';
+            $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
         }
 
         return $ths;
@@ -392,18 +406,8 @@ class DailyTimetablePrinter extends TimetablePrinter
         $nextPrayer = $this->getNextPrayer( $row );
 
         $localPrayerNames = $this->localPrayerNames;
-        if (get_option('zawal')) {
-            if ($this->dptHelper->isZawalTimeNext($row)) {
-                $localPrayerNames = $this->toggleSunriseZawal($row, $localPrayerNames);
-                $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
-            } else {
-                unset($localPrayerNames['zawal']);
-            }
-        } else {
-            unset($localPrayerNames['zawal']);
-        }
-
-        // Handle ishraq - merge into sunrise row
+        
+        // Handle ishraq - ONLY if ishraq is NEXT (not yet passed)
         $ishraqMins = get_option('ishraq');
         if ($ishraqMins && $ishraqMins != '0' && isset($localPrayerNames['ishraq'])) {
             if ($this->dptHelper->isIshraqTimeNext($row)) {
@@ -413,6 +417,17 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         if (isset($localPrayerNames['ishraq'])) {
             unset($localPrayerNames['ishraq']);
+        }
+        
+        // Handle zawal - ONLY if zawal is NEXT (not yet passed)
+        if (get_option('zawal')) {
+            if ($this->dptHelper->isZawalTimeNext($row)) {
+                $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
+                $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
+            }
+        }
+        if (isset($localPrayerNames['zawal'])) {
+            unset($localPrayerNames['zawal']);
         }
 
         foreach ($localPrayerNames as $key=>$prayerName) {

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -56,7 +56,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah');
         if ( $shouldHighlightJumuah || $showJumuah ) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $table .= '<tr class="' . $jumuahClass . '">
@@ -492,7 +492,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah');
         if ($shouldHighlightJumuah || $showJumuah) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -337,19 +337,31 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         $tds = '';
-        $nextPrayer =  $this->getNextPrayer( $row );
+$nextPrayer =  $this->getNextPrayer( $row );
+        
+        // On Friday, Zuhr should NOT be highlighted - only Jumuah
+        $onFriday = $this->todayIsFriday();
+        
         foreach ($jamahTimes as $key => $azan) {
-            // On Friday, don't highlight Zuhr - only Jumuah will be highlighted
-            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
-            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'class=highlight' : 'class=jamah';
-            $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</th>";
+            $shouldHighlight = false;
+            if ($onFriday) {
+                // On Friday, highlight only Jumuah, not Zuhr
+                $shouldHighlight = ($key == 'jumuah' || ($nextPrayer == 'jumuah' && $key != 'zuhr') || ($nextPrayer != 'jumuah' && $nextPrayer == $key));
+                // But don't highlight Zuhr on Friday
+                if ($key == 'zuhr') $shouldHighlight = false;
+            } else {
+                $shouldHighlight = ($nextPrayer == $key);
+            }
+            
+            $class = $shouldHighlight ? 'class=highlight' : 'class=jamah';
+            $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</td>";
         }
         
-        // On Friday, add Jumuah column at the END (after Isha)
-        if ($this->todayIsFriday() && get_option('jumuah1')) {
-            $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
-            $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
-        }
+        // // On Friday, add Jumuah column at the END (after Isha)
+        // if ($this->todayIsFriday() && get_option('jumuah1')) {
+        //     $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
+        //     $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
+        // }
 
         return $tds;
     }
@@ -478,10 +490,6 @@ class DailyTimetablePrinter extends TimetablePrinter
 
     private function getFormattedDateForPrayer($time, $prayerName, $isJamatTime=false)
     {
-//        $jumuahTime = get_option('jumuah1');
-//        if ( ($prayerName === 'zuhr' && $this->todayIsFriday()) && $isJamatTime && $jumuahTime) {
-//            return $this->getJumuahTimesArray();
-//        }
         return $this->formatDateForPrayer($time);
     }
 

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -261,9 +261,11 @@ class DailyTimetablePrinter extends TimetablePrinter
                 $shouldHighlight = true;
             }
             // On Friday with Jumuah, don't highlight Zuhr (Jumuah row is highlighted instead)
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+            $isFriday = $this->todayIsFriday();
+            if ($isFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
+            error_log("DEBUG printTableHeading: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");
             $class = $shouldHighlight ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
@@ -465,6 +467,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             if ($isFriday && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = false;
             }
+            error_log("DEBUG printVerticalRow: key=$key, nextPrayer=$nextPrayer, isFriday=$isFriday, shouldHighlight=$shouldHighlight");
             $class = $shouldHighlight ? 'highlight' : '';
             $highlightForJamah = $shouldHighlight ? 'highlight' : '';
 

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -43,8 +43,23 @@ class DailyTimetablePrinter extends TimetablePrinter
             '</tr>';
 
             $nextPrayer = $this->getNextPrayer( $row );
-        if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) {
-            $table .= '<tr>
+
+        // Determine whether to show Jumuah row: only when jumuah times are configured
+        // and current time is before the last configured Jumuah time (on Fridays).
+        $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
+        $showJumuah = false;
+        if (! empty($jumuahOptions) && $this->todayIsFriday()) {
+            $nowTs = strtotime( user_current_time('H:i') );
+            $lastJumuahTs = max( array_map('strtotime', $jumuahOptions) );
+            if ($nowTs < $lastJumuahTs) {
+                $showJumuah = true;
+            }
+        }
+
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+        if ( $shouldHighlightJumuah || $showJumuah ) {
+            $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
+            $table .= '<tr class="' . $jumuahClass . '">
                             <th class="tableHeading">' . stripslashes($this->getLocalHeaders()['jumuah']) . '</th>
                             <td colspan="6" class="jamah">' . $this->getJumuahTimesArray() . '</td>
                         </tr>';
@@ -229,7 +244,7 @@ class DailyTimetablePrinter extends TimetablePrinter
         
         // Handle zawal - show zawal instead of sunrise if zawal time is next
         if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
-            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
+            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'] ?? 'Zawal';
         }
         
         // Remove zawal - never show as separate prayer name
@@ -240,15 +255,14 @@ class DailyTimetablePrinter extends TimetablePrinter
         foreach ($localPrayerNames as $key=>$prayerName) {
             // On Friday, Zuhr stays as "Zuhr" but NOT highlighted
             $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
-            $shouldHighlight = (!$isFridayAndZuhr && $nextPrayer == $key);
-            $class = $shouldHighlight ? 'highlight' : '';
+            $shouldHighlight = false;
+            if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
+                $shouldHighlight = true;
+            } elseif ($key != 'sunrise' && $nextPrayer == $key) {
+                $shouldHighlight = true;
+            }
+            $class = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
-        }
-        
-        // Add Jumuah column on Friday at the END - ALWAYS HIGHLIGHT ON FRIDAY
-        if (($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr')) {
-            $jumuahClass = 'highlight';
-            $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
         }
 
         return $ths;
@@ -295,17 +309,16 @@ class DailyTimetablePrinter extends TimetablePrinter
         foreach ($azanTimings as $key => $azan) {
 
             $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
-            $shouldHighlight = (!$isFridayAndZuhr && $nextPrayer == $key);
+            $shouldHighlight = false;
+            if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
+                $shouldHighlight = true;
+            } elseif ($key != 'sunrise' && $nextPrayer == $key) {
+                $shouldHighlight = true;
+            }
 
             $class = $shouldHighlight ? "class='highlight'" : '';
             $rowspan = ($key == 'sunrise') ? "rowspan='2'" : '';
             $tds .= "<td ". $rowspan ." ".$class.">".$this->getFormattedDateForPrayer( $azan, $key)."</td>";
-        }
-        
-        // On Friday, add Jumuah column at the END - rowspan=2 to span azan and iqamah rows
-        if (($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr')) {
-            $jumuahClass = 'class=highlight';
-            $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
         }
 
         return $tds;
@@ -349,15 +362,18 @@ class DailyTimetablePrinter extends TimetablePrinter
         
         foreach ($jamahTimes as $key => $azan) {
             $shouldHighlight = false;
+            if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
+                $shouldHighlight = true;
+            } elseif ($key != 'sunrise' && $nextPrayer == $key) {
+                $shouldHighlight = true;
+            }
             if ($onFriday) {
                 // On Friday: highlight Jumuah if it's next, otherwise highlight next prayer (not Zuhr)
                 if ($nextPrayer == 'jumuah') {
                     $shouldHighlight = ($key == 'jumuah');
                 } elseif ($key != 'zuhr') {
-                    $shouldHighlight = ($key == $nextPrayer);
+                    $shouldHighlight = ($nextPrayer == $key);
                 }
-            } else {
-                $shouldHighlight = ($nextPrayer == $key);
             }
             
             $class = $shouldHighlight ? 'class=highlight' : 'class=jamah';
@@ -442,7 +458,7 @@ class DailyTimetablePrinter extends TimetablePrinter
         
         // Handle zawal - show zawal instead of sunrise if zawal time is next
         if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
-            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
+            $localPrayerNames['sunrise'] = $localPrayerNames['zawal'] ?? 'Zawal';
             $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
         }
         
@@ -457,8 +473,14 @@ class DailyTimetablePrinter extends TimetablePrinter
 
             // On Friday, don't highlight Zuhr - only Jumuah will be highlighted
             $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
-            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
-            $highlightForJamah = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
+            $shouldHighlight = false;
+            if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
+                $shouldHighlight = true;
+            } elseif ($key != 'sunrise' && $nextPrayer == $key) {
+                $shouldHighlight = true;
+            }
+            $class = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
+            $highlightForJamah = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
 
             $trs .= '<tr>
                     <th class="prayerName ' .$class.'">' . $prayerName . '</th>';
@@ -477,8 +499,20 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) {
-            $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+        // Determine whether to show Jumuah row: only when jumuah times are configured
+        // and current time is before the last configured Jumuah time (on Fridays).
+        $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
+        $showJumuah = false;
+        if (! empty($jumuahOptions) && $this->todayIsFriday()) {
+            $nowTs = strtotime( user_current_time('H:i') );
+            $lastJumuahTs = max( array_map('strtotime', $jumuahOptions) );
+            if ($nowTs < $lastJumuahTs) {
+                $showJumuah = true;
+            }
+        }
+
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
+        if ($shouldHighlightJumuah || $showJumuah) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>
                             <th class="prayerName ' . $jumuahClass . '"><span>' . stripslashes($this->getLocalHeaders()['jumuah']) . '</span></th>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -237,7 +237,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
         
-        // Add Jumuah column on Friday after Zuhr
+        // Add Jumuah column on Friday at the END (after Isha)
         if ($this->todayIsFriday() && get_option('jumuah1')) {
             $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
@@ -296,6 +296,12 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
             $tds .= "<td ". $rowspan ." ".$class.">".$this->getFormattedDateForPrayer( $azan, $key)."</th>";
         }
+        
+        // On Friday, add Jumuah column at the END (after Isha) for Azan
+        if ($this->todayIsFriday() && get_option('jumuah1')) {
+            $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : '';
+            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
+        }
 
         return $tds;
     }
@@ -337,14 +343,12 @@ class DailyTimetablePrinter extends TimetablePrinter
             $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
             $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'class=highlight' : 'class=jamah';
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</th>";
-            
-            // On Friday, add Jumuah column after Zuhr showing full Jumuah time
-            if ($this->todayIsFriday() && $key == 'zuhr' && get_option('jumuah1')) {
-                $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
-                // Display Jumuah times spanning this column
-                $jumuahTimes = $this->getJumuahTimesArray();
-                $tds .= "<td ".$jumuahClass." colspan='2'>".$jumuahTimes."</td>";
-            }
+        }
+        
+        // On Friday, add Jumuah column at the END (after Isha)
+        if ($this->todayIsFriday() && get_option('jumuah1')) {
+            $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
+            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
         }
 
         return $tds;

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -338,10 +338,12 @@ class DailyTimetablePrinter extends TimetablePrinter
             $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'class=highlight' : 'class=jamah';
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</th>";
             
-            // On Friday, add Jumuah column after Zuhr
+            // On Friday, add Jumuah column after Zuhr showing full Jumuah time
             if ($this->todayIsFriday() && $key == 'zuhr' && get_option('jumuah1')) {
                 $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
-                $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</th>";
+                // Display Jumuah times spanning this column
+                $jumuahTimes = $this->getJumuahTimesArray();
+                $tds .= "<td ".$jumuahClass." colspan='2'>".$jumuahTimes."</td>";
             }
         }
 

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -238,8 +238,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
         
-        // Add Jumuah column on Friday at the END (after Isha) - ALWAYS HIGHLIGHT ON FRIDAY
-        if ($this->todayIsFriday() && get_option('jumuah1')) {
+        // Add Jumuah column on Friday at the END - ALWAYS HIGHLIGHT ON FRIDAY
+        if (($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr')) {
             $jumuahClass = 'highlight';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
         }
@@ -249,12 +249,7 @@ class DailyTimetablePrinter extends TimetablePrinter
 
     private function toggleSunriseZawal($row, $prayerNames)
     {
-        // Only replace sunrise with zawal if zawal time is NEXT (not passed)
-        if ($this->dptHelper->isZawalTimeNext($row)) {
-            $prayerNames['sunrise'] = $prayerNames['zawal'];
-            unset($prayerNames['zawal']);
-        }
-
+        unset($prayerNames['zawal']);
         return $prayerNames;
     }
 
@@ -269,12 +264,6 @@ class DailyTimetablePrinter extends TimetablePrinter
         $nextPrayer = $this->getNextPrayer( $row );
         $azanTimings = $this->getAzanTime( $row );
 
-        if (get_option('zawal')) {
-            if ($this->dptHelper->isZawalTimeNext($row)) {
-                $azanTimings['sunrise'] = $this->dptHelper->getZawalTime($azanTimings['zuhr']);
-            }
-        }
-        
         // Handle ishraq - merge into sunrise row
         $ishraqMins = get_option('ishraq');
         if ($ishraqMins && $ishraqMins != '0' && isset($azanTimings['ishraq'])) {
@@ -286,19 +275,23 @@ class DailyTimetablePrinter extends TimetablePrinter
             unset($azanTimings['ishraq']);
         }
 
+        // Remove zawal - never show as separate time
+        if (isset($azanTimings['zawal'])) {
+            unset($azanTimings['zawal']);
+        }
+
         foreach ($azanTimings as $key => $azan) {
 
-            $class = $nextPrayer == $key ? 'class=highlight' : '';
-            $rowspan = '';
-            if ($key == 'sunrise')
-            {
-                $rowspan = "rowspan='2'";
-            }
-            $tds .= "<td ". $rowspan ." ".$class.">".$this->getFormattedDateForPrayer( $azan, $key)."</th>";
+            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            $shouldHighlight = (!$isFridayAndZuhr && $nextPrayer == $key);
+
+            $class = $shouldHighlight ? "class='highlight'" : '';
+            $rowspan = ($key == 'sunrise') ? "rowspan='2'" : '';
+            $tds .= "<td ". $rowspan ." ".$class.">".$this->getFormattedDateForPrayer( $azan, $key)."</td>";
         }
         
-        // On Friday, add Jumuah column at the END (after Isha) for Azan - ALWAYS HIGHLIGHT ON FRIDAY
-        if ($this->todayIsFriday() && get_option('jumuah1')) {
+        // On Friday, add Jumuah column at the END - rowspan=2 to span azan and iqamah rows
+        if (($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr')) {
             $jumuahClass = 'class=highlight';
             $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
         }
@@ -315,11 +308,6 @@ class DailyTimetablePrinter extends TimetablePrinter
     private function printJamahTime($row, $isSunrise=true)
     {
         $jamahTimes = $this->getJamahTime( $row );
-        if (get_option('zawal')) {
-            if ($this->dptHelper->isZawalTimeNext($row)) {
-                $jamahTimes['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
-            }
-        }
         
         // Handle ishraq - merge into sunrise row
         $ishraqMins = get_option('ishraq');
@@ -337,18 +325,20 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         $tds = '';
-$nextPrayer =  $this->getNextPrayer( $row );
+        $nextPrayer =  $this->getNextPrayer( $row );
         
-        // On Friday, Zuhr should NOT be highlighted - only Jumuah
+        // On Friday, only next prayer (not Zuhr) should be highlighted until Asr
         $onFriday = $this->todayIsFriday();
         
         foreach ($jamahTimes as $key => $azan) {
             $shouldHighlight = false;
             if ($onFriday) {
-                // On Friday, highlight only Jumuah, not Zuhr
-                $shouldHighlight = ($key == 'jumuah' || ($nextPrayer == 'jumuah' && $key != 'zuhr') || ($nextPrayer != 'jumuah' && $nextPrayer == $key));
-                // But don't highlight Zuhr on Friday
-                if ($key == 'zuhr') $shouldHighlight = false;
+                // On Friday: highlight Jumuah if it's next, otherwise highlight next prayer (not Zuhr)
+                if ($nextPrayer == 'jumuah') {
+                    $shouldHighlight = ($key == 'jumuah');
+                } elseif ($key != 'zuhr') {
+                    $shouldHighlight = ($key == $nextPrayer);
+                }
             } else {
                 $shouldHighlight = ($nextPrayer == $key);
             }
@@ -357,12 +347,6 @@ $nextPrayer =  $this->getNextPrayer( $row );
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</td>";
         }
         
-        // On Friday, add Jumuah column at the END (after Isha) - ALWAYS HIGHLIGHT ON FRIDAY
-        if ($this->todayIsFriday() && get_option('jumuah1')) {
-            $jumuahClass = 'class=highlight';
-            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
-        }
-
         return $tds;
     }
 
@@ -439,13 +423,7 @@ $nextPrayer =  $this->getNextPrayer( $row );
             unset($localPrayerNames['ishraq']);
         }
         
-        // Handle zawal - ONLY if zawal is NEXT (not yet passed)
-        if (get_option('zawal')) {
-            if ($this->dptHelper->isZawalTimeNext($row)) {
-                $localPrayerNames['sunrise'] = $localPrayerNames['zawal'];
-                $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
-            }
-        }
+        // Remove zawal - never show as separate prayer name
         if (isset($localPrayerNames['zawal'])) {
             unset($localPrayerNames['zawal']);
         }
@@ -476,7 +454,7 @@ $nextPrayer =  $this->getNextPrayer( $row );
             }
         }
 
-        if ( get_option('jumuah1') && $display != 'azan' ) {
+        if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) {
             $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr');
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -231,21 +231,15 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         
         foreach ($localPrayerNames as $key=>$prayerName) {
-            // On Friday, replace Zuhr with Jumuah in display
-            if ($this->todayIsFriday() && $key == 'zuhr') {
-                $prayerName = $this->localHeaders['jumuah'] ?? 'Jumuah';
-            }
-            $class = $nextPrayer == $key ? 'highlight' : '';
-            // On Friday, highlight Jumuah instead of Zuhr
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
-                $class = 'highlight';
-            }
+            // On Friday, Zuhr stays as "Zuhr" but NOT highlighted
+            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
         
-        // Add Jumuah column on Friday
+        // Add Jumuah column on Friday after Zuhr
         if ($this->todayIsFriday() && get_option('jumuah1')) {
-            $jumuahClass = $nextPrayer == 'jumuah' ? 'highlight' : '';
+            $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
         }
 
@@ -339,7 +333,9 @@ class DailyTimetablePrinter extends TimetablePrinter
         $tds = '';
         $nextPrayer =  $this->getNextPrayer( $row );
         foreach ($jamahTimes as $key => $azan) {
-            $class = $nextPrayer == $key ? 'class=highlight' : 'class=jamah';
+            // On Friday, don't highlight Zuhr - only Jumuah will be highlighted
+            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'class=highlight' : 'class=jamah';
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</th>";
             
             // On Friday, add Jumuah column after Zuhr
@@ -440,8 +436,10 @@ class DailyTimetablePrinter extends TimetablePrinter
             $begins =  $key != 'sunrise' ? lcfirst( $key ).'_begins' : 'sunrise';
             $jamah =  $key != 'sunrise' ? lcfirst( $key ).'_jamah' : 'sunrise';
 
-            $class = $nextPrayer == $key ? 'highlight' : '';
-            $highlightForJamah = $nextPrayer == $key ? 'highlight' : '';
+            // On Friday, don't highlight Zuhr - only Jumuah will be highlighted
+            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            $class = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
+            $highlightForJamah = (!$isFridayAndZuhr && $nextPrayer == $key) ? 'highlight' : '';
 
             $trs .= '<tr>
                     <th class="prayerName ' .$class.'">' . $prayerName . '</th>';

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -56,7 +56,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah');
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $showJumuah);
         if ( $shouldHighlightJumuah || $showJumuah ) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $table .= '<tr class="' . $jumuahClass . '">
@@ -497,7 +497,7 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah');
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $showJumuah);
         if ($shouldHighlightJumuah || $showJumuah) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -48,7 +48,8 @@ class DailyTimetablePrinter extends TimetablePrinter
         // and current time is before the last configured Jumuah time (on Fridays).
         $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
         $showJumuah = false;
-        if (! empty($jumuahOptions) && $this->todayIsFriday()) {
+        $isFriday = $this->todayIsFriday();
+        if (! empty($jumuahOptions) && $isFriday) {
             $nowTs = strtotime( user_current_time('H:i') );
             $lastJumuahTs = max( array_map('strtotime', $jumuahOptions) );
             if ($nowTs < $lastJumuahTs) {
@@ -56,7 +57,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $showJumuah);
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($isFriday && $showJumuah);
+        error_log("DEBUG printHorizontalTableTop: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah, shouldHighlightJumuah=$shouldHighlightJumuah");
         if ( $shouldHighlightJumuah || $showJumuah ) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $table .= '<tr class="' . $jumuahClass . '">
@@ -489,7 +491,8 @@ class DailyTimetablePrinter extends TimetablePrinter
         // and current time is before the last configured Jumuah time (on Fridays).
         $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
         $showJumuah = false;
-        if (! empty($jumuahOptions) && $this->todayIsFriday()) {
+        $isFriday = $this->todayIsFriday();
+        if (! empty($jumuahOptions) && $isFriday) {
             $nowTs = strtotime( user_current_time('H:i') );
             $lastJumuahTs = max( array_map('strtotime', $jumuahOptions) );
             if ($nowTs < $lastJumuahTs) {
@@ -497,7 +500,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             }
         }
 
-        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $showJumuah);
+        $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($isFriday && $showJumuah);
+        error_log("DEBUG printVerticalRow: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah, shouldHighlightJumuah=$shouldHighlightJumuah");
         if ($shouldHighlightJumuah || $showJumuah) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -218,6 +218,18 @@ class DailyTimetablePrinter extends TimetablePrinter
         if (get_option('zawal')) {
             $localPrayerNames = $this->toggleSunriseZawal($row, $localPrayerNames);
         }
+        
+        // Handle ishraq - merge into sunrise row, show only sunrise
+        $ishraqMins = get_option('ishraq');
+        if ($ishraqMins && $ishraqMins != '0' && isset($localPrayerNames['ishraq'])) {
+            if ($this->dptHelper->isIshraqTimeNext($row)) {
+                $localPrayerNames['sunrise'] = $localPrayerNames['ishraq'];
+            }
+        }
+        if (isset($localPrayerNames['ishraq'])) {
+            unset($localPrayerNames['ishraq']);
+        }
+        
         foreach ($localPrayerNames as $key=>$prayerName) {
             $class = $nextPrayer == $key ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
@@ -249,11 +261,21 @@ class DailyTimetablePrinter extends TimetablePrinter
         $nextPrayer = $this->getNextPrayer( $row );
         $azanTimings = $this->getAzanTime( $row );
 
-
         if (get_option('zawal')) {
             if ($this->dptHelper->isZawalTimeNext($row)) {
                 $azanTimings['sunrise'] = $this->dptHelper->getZawalTime($azanTimings['zuhr']);
             }
+        }
+        
+        // Handle ishraq - merge into sunrise row
+        $ishraqMins = get_option('ishraq');
+        if ($ishraqMins && $ishraqMins != '0' && isset($azanTimings['ishraq'])) {
+            if ($this->dptHelper->isIshraqTimeNext($row)) {
+                $azanTimings['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
+            }
+        }
+        if (isset($azanTimings['ishraq'])) {
+            unset($azanTimings['ishraq']);
         }
 
         foreach ($azanTimings as $key => $azan) {
@@ -284,6 +306,18 @@ class DailyTimetablePrinter extends TimetablePrinter
                 $jamahTimes['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
             }
         }
+        
+        // Handle ishraq - merge into sunrise row
+        $ishraqMins = get_option('ishraq');
+        if ($ishraqMins && $ishraqMins != '0' && isset($jamahTimes['ishraq'])) {
+            if ($this->dptHelper->isIshraqTimeNext($row)) {
+                $jamahTimes['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
+            }
+        }
+        if (isset($jamahTimes['ishraq'])) {
+            unset($jamahTimes['ishraq']);
+        }
+        
         if (! $isSunrise) {
             unset( $jamahTimes['sunrise'] );
         }
@@ -406,9 +440,10 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         if ( get_option('jumuah1') && $display != 'azan' ) {
+            $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
             $trs .= '<tr>
-                            <th class="prayerName"><span>' . stripslashes($this->getLocalHeaders()['jumuah']) . '</span></th>
-                            <td colspan="2" class="jamah">' . $this->getJumuahTimesArray() . '</td>
+                            <th class="prayerName ' . $jumuahClass . '"><span>' . stripslashes($this->getLocalHeaders()['jumuah']) . '</span></th>
+                            <td colspan="2" class="jamah ' . $jumuahClass . '">' . $this->getJumuahTimesArray() . '</td>
                         </tr>';
         }
 

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -238,9 +238,9 @@ class DailyTimetablePrinter extends TimetablePrinter
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
         
-        // Add Jumuah column on Friday at the END (after Isha) - HIGHLIGHT IT
+        // Add Jumuah column on Friday at the END (after Isha) - ALWAYS HIGHLIGHT ON FRIDAY
         if ($this->todayIsFriday() && get_option('jumuah1')) {
-            $jumuahClass = ($nextPrayer == 'jumuah') ? 'highlight' : '';
+            $jumuahClass = 'highlight';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $jumuahClass."'>".($this->localHeaders['jumuah'] ?? 'Jumuah')."</th>";
         }
 
@@ -249,12 +249,11 @@ class DailyTimetablePrinter extends TimetablePrinter
 
     private function toggleSunriseZawal($row, $prayerNames)
     {
+        // Only replace sunrise with zawal if zawal time is NEXT (not passed)
         if ($this->dptHelper->isZawalTimeNext($row)) {
             $prayerNames['sunrise'] = $prayerNames['zawal'];
             unset($prayerNames['zawal']);
-        } 
-
-        unset($prayerNames['zawal']);
+        }
 
         return $prayerNames;
     }
@@ -298,9 +297,9 @@ class DailyTimetablePrinter extends TimetablePrinter
             $tds .= "<td ". $rowspan ." ".$class.">".$this->getFormattedDateForPrayer( $azan, $key)."</th>";
         }
         
-        // On Friday, add Jumuah column at the END (after Isha) for Azan
+        // On Friday, add Jumuah column at the END (after Isha) for Azan - ALWAYS HIGHLIGHT ON FRIDAY
         if ($this->todayIsFriday() && get_option('jumuah1')) {
-            $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : '';
+            $jumuahClass = 'class=highlight';
             $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
         }
 
@@ -358,11 +357,11 @@ $nextPrayer =  $this->getNextPrayer( $row );
             $tds .= "<td ".$class.">".$this->getFormattedDateForPrayer( $azan, $key, true )."</td>";
         }
         
-        // // On Friday, add Jumuah column at the END (after Isha)
-        // if ($this->todayIsFriday() && get_option('jumuah1')) {
-        //     $jumuahClass = ($nextPrayer == 'jumuah') ? 'class=highlight' : 'class=jamah';
-        //     $tds .= "<td ".$jumuahClass." rowspan='2'>".$this->getJumuahTimesArray()."</td>";
-        // }
+        // On Friday, add Jumuah column at the END (after Isha) - ALWAYS HIGHLIGHT ON FRIDAY
+        if ($this->todayIsFriday() && get_option('jumuah1')) {
+            $jumuahClass = 'class=highlight';
+            $tds .= "<td ".$jumuahClass.">".$this->getJumuahTimesArray()."</td>";
+        }
 
         return $tds;
     }

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -58,7 +58,6 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($isFriday && $showJumuah);
-        error_log("DEBUG printHorizontalTableTop: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah, shouldHighlightJumuah=$shouldHighlightJumuah");
         if ( $shouldHighlightJumuah || $showJumuah ) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $table .= '<tr class="' . $jumuahClass . '">
@@ -255,15 +254,10 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         
         foreach ($localPrayerNames as $key=>$prayerName) {
-            // On Friday, when nextPrayer is 'jumuah', highlight Zuhr column (represents Jumuah)
             $shouldHighlight = false;
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
-                $shouldHighlight = true;
-            }
-            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr header
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = true;
             }
             $class = $shouldHighlight ? 'highlight' : '';
@@ -305,10 +299,6 @@ class DailyTimetablePrinter extends TimetablePrinter
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
-                $shouldHighlight = true;
-            }
-            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr azan time
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = true;
             }
 
@@ -354,10 +344,6 @@ class DailyTimetablePrinter extends TimetablePrinter
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
-                $shouldHighlight = true;
-            }
-            // On Friday, nextPrayer is 'jumuah' but we're in the Zuhr column - still highlight
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = true;
             }
             
@@ -456,15 +442,10 @@ class DailyTimetablePrinter extends TimetablePrinter
             $begins =  $key != 'sunrise' ? lcfirst( $key ).'_begins' : 'sunrise';
             $jamah =  $key != 'sunrise' ? lcfirst( $key ).'_jamah' : 'sunrise';
 
-            // On Friday, when nextPrayer is 'jumuah', highlight the Zuhr row (shows Jumuah times)
             $shouldHighlight = false;
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
-                $shouldHighlight = true;
-            }
-            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr row
-            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = true;
             }
             $class = $shouldHighlight ? 'highlight' : '';
@@ -501,7 +482,6 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
 
         $shouldHighlightJumuah = ($nextPrayer == 'jumuah') || ($isFriday && $showJumuah);
-        error_log("DEBUG printVerticalRow: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah, shouldHighlightJumuah=$shouldHighlightJumuah");
         if ($shouldHighlightJumuah || $showJumuah) {
             $jumuahClass = $shouldHighlightJumuah ? 'highlight' : '';
             $trs .= '<tr>

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -285,25 +285,13 @@ class DailyTimetablePrinter extends TimetablePrinter
         $nextPrayer = $this->getNextPrayer( $row );
         $azanTimings = $this->getAzanTime( $row );
 
-        // Handle ishraq - merge into sunrise row
+        // Handle ishraq - merge into sunrise row (check FIRST)
         $ishraqMins = get_option('ishraq');
-        if ($ishraqMins && $ishraqMins != '0' && isset($azanTimings['ishraq'])) {
-            if ($this->dptHelper->isIshraqTimeNext($row)) {
-                $azanTimings['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
-            }
-        }
-        if (isset($azanTimings['ishraq'])) {
-            unset($azanTimings['ishraq']);
-        }
-
-        // Handle zawal - show zawal time instead of sunrise if zawal time is next
-        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+        if ($ishraqMins && $ishraqMins != '0' && $this->dptHelper->isIshraqTimeNext($row)) {
+            $azanTimings['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
+        } elseif (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            // Handle zawal - show zawal time instead of sunrise if zawal time is next
             $azanTimings['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
-        }
-
-        // Remove zawal - never show as separate time
-        if (isset($azanTimings['zawal'])) {
-            unset($azanTimings['zawal']);
         }
 
         foreach ($azanTimings as $key => $azan) {
@@ -334,22 +322,15 @@ class DailyTimetablePrinter extends TimetablePrinter
     {
         $jamahTimes = $this->getJamahTime( $row );
         
-        // Handle ishraq - merge into sunrise row
+        // Handle ishraq - merge into sunrise row (check FIRST)
         $ishraqMins = get_option('ishraq');
-        if ($ishraqMins && $ishraqMins != '0' && isset($jamahTimes['ishraq'])) {
-            if ($this->dptHelper->isIshraqTimeNext($row)) {
-                $jamahTimes['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
-            }
-        }
-        if (isset($jamahTimes['ishraq'])) {
-            unset($jamahTimes['ishraq']);
-        }
-
-        // Handle zawal - show zawal time instead of sunrise if zawal time is next
-        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+        if ($ishraqMins && $ishraqMins != '0' && $this->dptHelper->isIshraqTimeNext($row)) {
+            $jamahTimes['sunrise'] = $this->dptHelper->getIshraqTime($row['sunrise']);
+        } elseif (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+            // Handle zawal - show zawal time instead of sunrise if zawal time is next
             $jamahTimes['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
         }
-        
+
         if (! $isSunrise) {
             unset( $jamahTimes['sunrise'] );
         }
@@ -444,7 +425,7 @@ class DailyTimetablePrinter extends TimetablePrinter
 
         $localPrayerNames = $this->localPrayerNames;
         
-        // Handle ishraq - ONLY if ishraq is NEXT (not yet passed)
+        // Handle ishraq - ONLY if ishraq is NEXT (not yet passed) - check FIRST
         $ishraqMins = get_option('ishraq');
         if ($ishraqMins && $ishraqMins != '0' && isset($localPrayerNames['ishraq'])) {
             if ($this->dptHelper->isIshraqTimeNext($row)) {
@@ -456,8 +437,8 @@ class DailyTimetablePrinter extends TimetablePrinter
             unset($localPrayerNames['ishraq']);
         }
         
-        // Handle zawal - show zawal instead of sunrise if zawal time is next
-        if (get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
+        // Handle zawal - show zawal instead of sunrise if zawal time is next (only if ishraq not next)
+        if (!$this->dptHelper->isIshraqTimeNext($row) && get_option('zawal') && $this->dptHelper->isZawalTimeNext($row)) {
             $localPrayerNames['sunrise'] = $localPrayerNames['zawal'] ?? 'Zawal';
             $row['sunrise'] = $this->dptHelper->getZawalTime($row['zuhr_begins']);
         }

--- a/Views/DailyTimetablePrinter.php
+++ b/Views/DailyTimetablePrinter.php
@@ -253,15 +253,18 @@ class DailyTimetablePrinter extends TimetablePrinter
         }
         
         foreach ($localPrayerNames as $key=>$prayerName) {
-            // On Friday, Zuhr stays as "Zuhr" but NOT highlighted
-            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            // On Friday, when nextPrayer is 'jumuah', highlight Zuhr column (represents Jumuah)
             $shouldHighlight = false;
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            $class = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
+            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr header
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = true;
+            }
+            $class = $shouldHighlight ? 'highlight' : '';
             $ths .= "<th class='tableHeading prayerName" . $this->tableClass . " ". $class."'>".$prayerName."</th>";
         }
 
@@ -296,11 +299,14 @@ class DailyTimetablePrinter extends TimetablePrinter
 
         foreach ($azanTimings as $key => $azan) {
 
-            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
             $shouldHighlight = false;
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
+                $shouldHighlight = true;
+            }
+            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr azan time
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
                 $shouldHighlight = true;
             }
 
@@ -348,13 +354,9 @@ class DailyTimetablePrinter extends TimetablePrinter
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            if ($onFriday) {
-                // On Friday: highlight Jumuah if it's next, otherwise highlight next prayer (not Zuhr)
-                if ($nextPrayer == 'jumuah') {
-                    $shouldHighlight = ($key == 'jumuah');
-                } elseif ($key != 'zuhr') {
-                    $shouldHighlight = ($nextPrayer == $key);
-                }
+            // On Friday, nextPrayer is 'jumuah' but we're in the Zuhr column - still highlight
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = true;
             }
             
             $class = $shouldHighlight ? 'class=highlight' : 'class=jamah';
@@ -452,16 +454,19 @@ class DailyTimetablePrinter extends TimetablePrinter
             $begins =  $key != 'sunrise' ? lcfirst( $key ).'_begins' : 'sunrise';
             $jamah =  $key != 'sunrise' ? lcfirst( $key ).'_jamah' : 'sunrise';
 
-            // On Friday, don't highlight Zuhr - only Jumuah will be highlighted
-            $isFridayAndZuhr = ($this->todayIsFriday() && $key == 'zuhr');
+            // On Friday, when nextPrayer is 'jumuah', highlight the Zuhr row (shows Jumuah times)
             $shouldHighlight = false;
             if ($key == 'sunrise' && $nextPrayer == 'ishraq') {
                 $shouldHighlight = true;
             } elseif ($key != 'sunrise' && $nextPrayer == $key) {
                 $shouldHighlight = true;
             }
-            $class = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
-            $highlightForJamah = (!$isFridayAndZuhr && $shouldHighlight) ? 'highlight' : '';
+            // On Friday, nextPrayer is 'jumuah' - highlight Zuhr row
+            if ($this->todayIsFriday() && $nextPrayer == 'jumuah' && $key == 'zuhr') {
+                $shouldHighlight = true;
+            }
+            $class = $shouldHighlight ? 'highlight' : '';
+            $highlightForJamah = $shouldHighlight ? 'highlight' : '';
 
             $trs .= '<tr>
                     <th class="prayerName ' .$class.'">' . $prayerName . '</th>';

--- a/Views/TimetablePrinter.php
+++ b/Views/TimetablePrinter.php
@@ -431,6 +431,9 @@ class TimetablePrinter
         if ($nextPrayer == 'ishraq') {
             return $this->localPrayerNames['ishraq'];
         }
+        if ($nextPrayer == 'jumuah') {
+            return $this->localHeaders['jumuah'];
+        }
         if ( is_null($nextPrayer)) {
             return $this->localPrayerNames['fajr'].' '. $iqamah;
         }
@@ -449,7 +452,9 @@ class TimetablePrinter
             $nextPrayer = 'zuhr';
         }
 
-        if ($nextPrayer == 'ishraq') {
+        if ($nextPrayer == 'jumuah') {
+            $nextPrayerTime = $dbRow['zuhr_jamah'];
+        } elseif ($nextPrayer == 'ishraq') {
             $nextPrayerTime = $this->dptHelper->getIshraqTime($dbRow['sunrise']);
         } else {
             $key = ($nextPrayer == 'sunrise') ? $nextPrayer : strtolower($nextPrayer.'_jamah');
@@ -458,7 +463,7 @@ class TimetablePrinter
                 $nextPrayerTime = $dbRow[$key];
             }
 
-            if (is_null($nextPrayer)) {
+            if (is_null($nextPrayerTime)) {
                 $nextPrayerTime = $dbRow['nextFajr'];
             }
         }

--- a/Views/horizontal-div.php
+++ b/Views/horizontal-div.php
@@ -88,15 +88,17 @@ if ($sunriseOrZawal == 'zawal') {
         // Check if Jumuah times are set and current time is before last Jumuah
         $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
         $showJumuah = false;
-        if (!empty($jumuahOptions) && $this->todayIsFriday()) {
+        $isFriday = $this->todayIsFriday();
+        if (!empty($jumuahOptions) && $isFriday) {
             $nowTs = strtotime(user_current_time('H:i'));
             $lastJumuahTs = max(array_map('strtotime', $jumuahOptions));
             if ($nowTs < $lastJumuahTs) {
                 $showJumuah = true;
             }
         }
+        error_log("DEBUG horizontal-div: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah");
         if ($showJumuah) { ?>
-            <div class="prayer-time prayer-jumuah <?php if (strtolower($nextPrayer) == 'jumuah') echo "highlight"; ?>">
+            <div class="prayer-time prayer-jumuah <?php if ($isFriday && $showJumuah) echo "highlight"; ?>">
                 <span class="iconify-inline dptPrayerIcon" data-icon="fa-solid:mosque""></span>
 
                 <h3><?php echo esc_html( $this->headersLocal['jumuah'] )?></h3>

--- a/Views/horizontal-div.php
+++ b/Views/horizontal-div.php
@@ -96,7 +96,6 @@ if ($sunriseOrZawal == 'zawal') {
                 $showJumuah = true;
             }
         }
-        error_log("DEBUG horizontal-div: nextPrayer=$nextPrayer, isFriday=$isFriday, showJumuah=$showJumuah");
         if ($showJumuah) { ?>
             <div class="prayer-time prayer-jumuah <?php if ($isFriday && $showJumuah) echo "highlight"; ?>">
                 <span class="iconify-inline dptPrayerIcon" data-icon="fa-solid:mosque""></span>

--- a/Views/horizontal-div.php
+++ b/Views/horizontal-div.php
@@ -84,8 +84,19 @@ if ($sunriseOrZawal == 'zawal') {
             <div class="prayer-jamaat"><?php echo  esc_html( $this->formatDateForPrayer($row["isha_jamah"]) );?></div>
 
         </div> <!-- END of prayer time-->
-        <?php if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) { ?>
-            <div class="prayer-time prayer-jumuah <?php if ('nextPrayer' ==  $this->getNextPrayerClass('jumuah', $row)) echo "highlight"; ?>">
+        <?php 
+        // Check if Jumuah times are set and current time is before last Jumuah
+        $jumuahOptions = array_filter([ get_option('jumuah1'), get_option('jumuah2'), get_option('jumuah3') ]);
+        $showJumuah = false;
+        if (!empty($jumuahOptions) && $this->todayIsFriday()) {
+            $nowTs = strtotime(user_current_time('H:i'));
+            $lastJumuahTs = max(array_map('strtotime', $jumuahOptions));
+            if ($nowTs < $lastJumuahTs) {
+                $showJumuah = true;
+            }
+        }
+        if ($showJumuah) { ?>
+            <div class="prayer-time prayer-jumuah <?php if ($nextPrayer == 'jumuah') echo "highlight"; ?>">
                 <span class="iconify-inline dptPrayerIcon" data-icon="fa-solid:mosque""></span>
 
                 <h3><?php echo esc_html( $this->headersLocal['jumuah'] )?></h3>

--- a/Views/horizontal-div.php
+++ b/Views/horizontal-div.php
@@ -96,7 +96,7 @@ if ($sunriseOrZawal == 'zawal') {
             }
         }
         if ($showJumuah) { ?>
-            <div class="prayer-time prayer-jumuah <?php if ($nextPrayer == 'jumuah') echo "highlight"; ?>">
+            <div class="prayer-time prayer-jumuah <?php if (strtolower($nextPrayer) == 'jumuah') echo "highlight"; ?>">
                 <span class="iconify-inline dptPrayerIcon" data-icon="fa-solid:mosque""></span>
 
                 <h3><?php echo esc_html( $this->headersLocal['jumuah'] )?></h3>

--- a/Views/horizontal-div.php
+++ b/Views/horizontal-div.php
@@ -44,10 +44,10 @@ if ($sunriseOrZawal == 'zawal') {
             <div class="prayer-jamaat"><?php echo  esc_html( $this->formatDateForPrayer($row["fajr_jamah"]) );?></div>
 
         </div> <!-- END of prayer time-->
-        <div class="prayer-time prayer-sunrise <?php if ($nextPrayer == $sunriseOrZawal) echo "highlight"; ?>">
+        <div class="prayer-time prayer-sunrise <?php if ($sunriseOrZawal == 'ishraq' && strtolower($nextPrayer) == 'ishraq') echo "highlight"; ?>">
         <span class="iconify-inline dptPrayerIcon" data-icon="bi:sunrise-fill"></span>
 
-            <h3><?php echo esc_html( $this->localPrayerNames[$sunriseOrZawal] )?></h3>
+            <h3><?php echo esc_html( $this->localPrayerNames[$sunriseOrZawal] ?? ucfirst($sunriseOrZawal) )?></h3>
             <div class="prayer-jamaat"><?php echo  esc_html( $sunriseOrZawalTime );?></div>
             <div>&nbsp;</div>
 
@@ -84,7 +84,7 @@ if ($sunriseOrZawal == 'zawal') {
             <div class="prayer-jamaat"><?php echo  esc_html( $this->formatDateForPrayer($row["isha_jamah"]) );?></div>
 
         </div> <!-- END of prayer time-->
-        <?php if (get_option('jumuah1')) { ?>
+        <?php if ( ($nextPrayer == 'jumuah') || ($this->todayIsFriday() && $nextPrayer == 'zuhr') ) { ?>
             <div class="prayer-time prayer-jumuah <?php if ('nextPrayer' ==  $this->getNextPrayerClass('jumuah', $row)) echo "highlight"; ?>">
                 <span class="iconify-inline dptPrayerIcon" data-icon="fa-solid:mosque""></span>
 


### PR DESCRIPTION
## Summary
- Fix timezone issue in `isZawalTimeNext` by using `user_current_time` for consistent datetime comparison
- Show zawal name instead of sunrise when zawal is next (with fallback to 'Zawal' if not in custom prayer names)
- Only highlight ishraq row when ishraq is next (not zawal)
- Only highlight zuhr row when zawal is next (not sunrise/zawal row)
- Fix ishraq highlighting in horizontal table's `printAzanTime` method
- Fix jumuah display logic to show row only when times are set and current time is before last jumuah time

## Files Changed
- `Models/DPTHelper.php` - Timezone fix and highlighting logic
- `Views/DailyTimetablePrinter.php` - Display and highlighting fixes for horizontal/vertical tables
- `Views/horizontal-div.php` - Highlight condition fix for div layout