### PR TITLE
Fix: Display Quran verse and simplify usman template CSS

### DIFF
--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -136,7 +136,7 @@
 }
 
 .d-masjid-e-usman .digital-clock h2 {
-    font-size: clamp(48px, 12vw, 120px);
+    font-size: clamp(48px, 12vw, 100px);
     font-weight: 900;
     display: inline-block;
     text-shadow: 7px 7px black;
@@ -172,7 +172,7 @@
 
 .d-masjid-e-usman .seconds-count h4 {
     font-family: "DSDIGI" , sans-serif;
-    font-size: clamp(28px, 6vw, 45px);
+    font-size: clamp(28px, 6vw, 40px);
     font-weight: 600;
     margin-bottom: 0;
     display: block;
@@ -182,7 +182,7 @@
 
 .d-masjid-e-usman .seconds-count p {
     margin-bottom: 0;
-    font-size: clamp(20px, 4vw, 35px);
+    font-size: clamp(20px, 4vw, 30px);
     font-family: Arial, Helvetica, sans-serif;
     display: inline;
     line-height: 1.2;

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -562,7 +562,57 @@
     /* ── Layout ── */
     .d-masjid-e-usman {
         height: auto;
+        min-height: 100vh;
     }
+
+    .d-masjid-e-usman .banner-section {
+        height: calc(100% - 100px);
+        min-height: 250px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+    
+    .d-masjid-e-usman .top-header-row {
+        flex: 0 0 60px;
+        min-height: 60px;
+    }
+
+    /* Mobile logo — compact header strip */
+    .d-masjid-e-usman .mobile-logo-row {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(86,247,79,0.3);
+        background: rgba(0,0,0,0.25);
+    }
+
+    /* Hide desktop bottom overlay on mobile */
+    .d-masjid-e-usman .mosque-info-overlay.desktop-only {
+        display: none;
+    }
+
+    /* Ensure Quran verse is centered on mobile */
+    .d-masjid-e-usman #quranVerse {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+        text-align: center;
+    }
+
+    .d-masjid-e-usman #quranVerse p {
+        font-size: clamp(22px, 4vw, 36px);
+    }
+
+    .d-masjid-e-usman #quranVerse .sura {
+        font-size: clamp(14px, 2.5vw, 22px);
+    }
+}
 
     .d-masjid-e-usman .banner-section {
         height: calc(100% - 70px);

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -562,57 +562,7 @@
     /* ── Layout ── */
     .d-masjid-e-usman {
         height: auto;
-        min-height: 100vh;
     }
-
-    .d-masjid-e-usman .banner-section {
-        height: calc(100% - 100px);
-        min-height: 250px;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-    }
-    
-    .d-masjid-e-usman .top-header-row {
-        flex: 0 0 60px;
-        min-height: 60px;
-    }
-
-    /* Mobile logo — compact header strip */
-    .d-masjid-e-usman .mobile-logo-row {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 8px 0;
-        border-bottom: 1px solid rgba(86,247,79,0.3);
-        background: rgba(0,0,0,0.25);
-    }
-
-    /* Hide desktop bottom overlay on mobile */
-    .d-masjid-e-usman .mosque-info-overlay.desktop-only {
-        display: none;
-    }
-
-    /* Ensure Quran verse is centered on mobile */
-    .d-masjid-e-usman #quranVerse {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        width: 100%;
-        height: 100%;
-        text-align: center;
-    }
-
-    .d-masjid-e-usman #quranVerse p {
-        font-size: clamp(22px, 4vw, 36px);
-    }
-
-    .d-masjid-e-usman #quranVerse .sura {
-        font-size: clamp(14px, 2.5vw, 22px);
-    }
-}
 
     .d-masjid-e-usman .banner-section {
         height: calc(100% - 70px);

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -406,7 +406,11 @@
 }
 
 .d-masjid-e-usman #quranVerse .quranVerse {
-    padding: 20px;
+    padding: 30px;
+    border: 3px solid rgb(86,247,79);
+    border-radius: 15px;
+    background: rgba(0,0,0,0.5);
+    max-width: 90%;
 }
 
 .d-masjid-e-usman #quranVerse blockquote {

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -348,12 +348,28 @@
 
 .d-masjid-e-usman .banner-section {
     margin: 0;
-    height: 85%;
+    height: 100%;
     padding: 25px 20px 0 20px;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+}
+
+.d-masjid-e-usman .banner-section .carousel-item {
+    display: flex !important;
+    flex-direction: column;
+    justify-content: center !important;
+    align-items: center !important;
+    height: 100%;
+}
+
+.d-masjid-e-usman .banner-section .nextPrayer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
 }
 
 .d-masjid-e-usman .banner-section img {
@@ -753,6 +769,9 @@
         height: 100%;
         border-radius: 6px;
         overflow: hidden;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .d-masjid-e-usman .banner-section img {

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -683,11 +683,25 @@
         line-height: 1.3;
     }
 
-    /* ── Prayer table ── */
+/* ── Prayer table ── */
     .d-masjid-e-usman .left-main-col-prayernames {
-        height: auto;
-        padding-top: 4px;
-        border-bottom: 2px solid rgba(194,194,194,0.5);
+        padding-top: 2px;
+        margin-bottom: 2px;
+    }
+
+    /* Prayer name - tighter */
+    .d-masjid-e-usman .title-value {
+        padding-top: 0;
+        padding-left: 2px;
+        line-height: 1.1;
+    }
+
+    /* Time values - tighter */
+    .d-masjid-e-usman .time-value h3,
+    .d-masjid-e-usman .jummah {
+        text-shadow: 2px 2px black;
+        line-height: 1.1;
+        font-size: 18px;
     }
 
     /* Column headers */
@@ -703,16 +717,15 @@
         color: rgba(255,255,255,0.7);
     }
 
-    /* Prayer rows — alternating subtle background for readability */
+    /* Prayer rows — tighter spacing on mobile */
     .d-masjid-e-usman .fajr-section,
     .d-masjid-e-usman .zuhr-section,
     .d-masjid-e-usman .asr-section,
     .d-masjid-e-usman .maghrib-section,
     .d-masjid-e-usman .isha-section,
     .d-masjid-e-usman .jummah-section {
-        padding: 5px 0;
+        padding: 2px 0;
         align-items: center;
-        border-radius: 4px;
         margin: 1px 0;
     }
 
@@ -853,8 +866,8 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
-   SMALL MOBILE  (≤ 380px)
-═══════════════════════════════════════════════════════════════════════ */
+    SMALL MOBILE  (≤ 380px)
+   ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 380px) {
     .d-masjid-e-usman .digital-clock h2 {
         font-size: 40px;
@@ -864,13 +877,28 @@
         font-size: 20px;
     }
 
+    /* Tighter prayer rows */
+    .d-masjid-e-usman .left-main-col-prayernames {
+        padding: 0;
+    }
+
+    .d-masjid-e-usman .fajr-section,
+    .d-masjid-e-usman .zuhr-section,
+    .d-masjid-e-usman .asr-section,
+    .d-masjid-e-usman .maghrib-section,
+    .d-masjid-e-usman .isha-section,
+    .d-masjid-e-usman .jummah-section {
+        padding: 1px 0;
+        margin: 0;
+    }
+
     .d-masjid-e-usman .title-value {
-        font-size: 14px;
+        font-size: 12px;
     }
 
     .d-masjid-e-usman .time-value h3,
     .d-masjid-e-usman .jummah {
-        font-size: 15px;
+        font-size: 14px;
     }
 
     .d-masjid-e-usman .left-main-col-sun-times p {

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -73,6 +73,8 @@
 @media (max-width: 767px) {
     .d-masjid-e-usman .top-header-row {
         display: flex !important;
+        flex: 0 !important;
+        background: none !important;
     }
     
     .d-masjid-e-usman .mosque-info-overlay.desktop-only {
@@ -348,12 +350,63 @@
     margin: 0;
     height: 85%;
     padding: 25px 20px 0 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
 .d-masjid-e-usman .banner-section img {
     height: 100%;
     width: 100%;
     border: 1px solid rgb(255, 255, 255);
+}
+
+/* ─── QURAN VERSE ─────────────────────────────────────────────────── */
+
+.d-masjid-e-usman #quranVerse {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    color: rgb(86,247,79);
+}
+
+.d-masjid-e-usman #quranVerse .quranVerse {
+    padding: 20px;
+}
+
+.d-masjid-e-usman #quranVerse blockquote {
+    margin: 0;
+    padding: 0;
+    border: none;
+}
+
+.d-masjid-e-usman #quranVerse p {
+    font-size: clamp(28px, 4vw, 48px);
+    color: #fff;
+    margin-bottom: 20px;
+    line-height: 1.4;
+    text-shadow: 3px 3px black;
+}
+
+.d-masjid-e-usman #quranVerse .link {
+    margin-top: 15px;
+}
+
+.d-masjid-e-usman #quranVerse .sura {
+    font-size: clamp(18px, 2.5vw, 28px);
+    color: rgb(86,247,79);
+    display: block;
+    margin-top: 10px;
+}
+
+.d-masjid-e-usman #quranVerse a {
+    color: rgb(86,247,79);
+    text-decoration: none;
 }
 
 .d-masjid-e-usman .logo-section img {

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -23,6 +23,40 @@
     overflow: hidden;
 }
 
+/* ─── TOP HEADER ───────────────────────────────────────────────────── */
+.d-masjid-e-usman .top-header-row {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    padding: 10px 20px;
+    background: rgba(0,0,0,0.3);
+    border-bottom: 2px solid rgb(86,247,79);
+}
+
+.d-masjid-e-usman .logo-section-top {
+    flex: 0 0 auto;
+    width: auto;
+}
+
+.d-masjid-e-usman .logo-section-top img {
+    max-height: 60px;
+    width: auto;
+}
+
+.d-masjid-e-usman .mosque-name-top {
+    flex: 1;
+    text-align: left;
+    padding-left: 20px;
+}
+
+.d-masjid-e-usman .mosque-name-top h1 {
+    color: #d7d7d7;
+    font-family: "BebasNeueRegular";
+    font-size: clamp(28px, 5vw, 48px);
+    margin: 0;
+    text-shadow: 3px 3px black;
+}
+
 .d-masjid-e-usman .row {
     flex: 1;
     display: flex;
@@ -119,7 +153,6 @@
     display: block;
     line-height: 1.1;
     text-shadow: 5px 5px black;
-    padding-left: 9px;
 }
 
 .d-masjid-e-usman .seconds-count p {
@@ -453,7 +486,7 @@
     /* Clock digits */
     .d-masjid-e-usman .digital-clock {
         align-items: center;
-        padding: 0;
+        padding-left: 30px;
     }
 
     .d-masjid-e-usman .digital-clock h2 {
@@ -490,7 +523,6 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        padding-left: 6px;
     }
 
     .d-masjid-e-usman .seconds-count h4 {
@@ -564,7 +596,6 @@
 
     /* Prayer name */
     .d-masjid-e-usman .title-value {
-        font-size: 16px;
         font-weight: bold;
         padding-top: 0;
         padding-left: 4px;
@@ -574,7 +605,6 @@
     /* Time values */
     .d-masjid-e-usman .time-value h3,
     .d-masjid-e-usman .jummah {
-        font-size: 18px;
         text-shadow: 2px 2px black;
         line-height: 1.2;
     }
@@ -611,7 +641,6 @@
     }
 
     .d-masjid-e-usman .left-main-col-sun-times p {
-        font-size: 9px;
         letter-spacing: 0;
         padding-top: 4px;
         line-height: 1.2;
@@ -621,7 +650,6 @@
     }
 
     .d-masjid-e-usman .left-main-col-sun-times h4 {
-        font-size: 17px;
         line-height: 1.2;
     }
 

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -383,6 +383,10 @@
     display: none;
 }
 
+.d-masjid-e-usman .mosque-info-overlay.desktop-only {
+    display: flex;
+}
+
 .d-masjid-e-usman .isha-jamah-time {
     padding-right: 0;
 }
@@ -462,6 +466,11 @@
         padding: 8px 0;
         border-bottom: 1px solid rgba(86,247,79,0.3);
         background: rgba(0,0,0,0.25);
+    }
+
+    /* Hide desktop bottom overlay on mobile */
+    .d-masjid-e-usman .mosque-info-overlay.desktop-only {
+        display: none;
     }
 
     .d-masjid-e-usman .mobile-logo-row img {
@@ -596,7 +605,6 @@
 
     /* Prayer name */
     .d-masjid-e-usman .title-value {
-        font-weight: bold;
         padding-top: 0;
         padding-left: 4px;
         line-height: 1.2;
@@ -607,6 +615,7 @@
     .d-masjid-e-usman .jummah {
         text-shadow: 2px 2px black;
         line-height: 1.2;
+        font-size: 20px;
     }
 
     /* Remove desktop fixed padding on start times */

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -792,7 +792,6 @@
         height: 100%;
         border-radius: 6px;
         overflow: hidden;
-        display: flex;
         justify-content: center;
         align-items: center;
     }

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -8,41 +8,41 @@
     src: local('BebasNeueRegula'), url('./BebasNeue-Regular.ttf') format('truetype');
 }
 
-.usman-body{
+.usman-body {
     padding: 0;
     margin: 0;
-    background-image: linear-gradient(to left top ,  black , rgb(1,48,42) , rgb(6 ,99, 88) , rgb(6 ,99, 88) , rgb(1,48,42) , black );  
+    background-image: linear-gradient(to left top, black, rgb(1,48,42), rgb(6,99,88), rgb(6,99,88), rgb(1,48,42), black);
     height: 100%;
     width: 100%;
+}
+
+.d-masjid-e-usman {
+    height: 100vh;
 }
 
 .d-masjid-e-usman .left-main-column {
     padding-left: 50px;
 }
 
-.d-masjid-e-usman{
-    height: 100vh;
-}
-
-.d-masjid-e-usman .left-main-col-dateandtime{
+.d-masjid-e-usman .left-main-col-dateandtime {
     border-bottom: 5px solid rgb(194, 194, 194);
     text-align: left;
     height: 20%;
 }
 
 .d-masjid-e-usman .left-main-col-prayernames {
-    height : 80% ;
+    height: 80%;
     padding-top: 17px;
 }
 
 .d-masjid-e-usman .digital-clock {
     font-family: "DSDIGI" , sans-serif;
-    color: rgb(86,247,79); 
+    color: rgb(86,247,79);
     display: flex;
 }
 
-.d-masjid-e-usman .digital-clock h2{
-    font-size: 7vw;
+.d-masjid-e-usman .digital-clock h2 {
+    font-size: clamp(20px, 7vw, 120px);
     font-weight: 800;
     display: inline-block;
     text-shadow: 7px 7px black;
@@ -64,97 +64,100 @@
     max-width: 10%;
 }
 
-.d-masjid-e-usman .digital-clock h2#hours{
-    margin-right: 10px;
+.d-masjid-e-usman .digital-clock h2#hours {
+    margin-right: 30px;
     text-align: right;
 }
 
-.d-masjid-e-usman .digital-clock h2#min{
+.d-masjid-e-usman .digital-clock h2#min {
     margin-left: 5px;
 }
-.d-masjid-e-usman .banner-section{
+
+.d-masjid-e-usman .banner-section {
     margin: 0;
     height: 85%;
     padding: 25px 20px 0 20px;
 }
 
-.d-masjid-e-usman .banner-section img{
+.d-masjid-e-usman .banner-section img {
     height: 100%;
     width: 100%;
     border: 1px solid rgb(255, 255, 255);
 }
 
-.d-masjid-e-usman .logo-section img{
+.d-masjid-e-usman .logo-section img {
     height: 100%;
-    padding: 10px 0px 0px 20px;
+    padding: 10px 0 0 20px;
     max-width: 100px;
 }
 
-.d-masjid-e-usman .seconds-count{
+.d-masjid-e-usman .seconds-count {
     color: rgb(86,247,79);
     padding-top: 10px;
 }
 
-.d-masjid-e-usman .seconds-count h4{
+.d-masjid-e-usman .seconds-count h4 {
     font-family: "DSDIGI" , sans-serif;
-    font-size: 60px;
+    font-size: clamp(20px, 4vw, 60px);
     font-weight: 600;
     margin-bottom: 0;
     display: block;
-    line-height: 65px;
+    line-height: 1.1;
     text-shadow: 5px 5px black;
     padding-left: 9px;
 }
 
-.d-masjid-e-usman .seconds-count p{
+.d-masjid-e-usman .seconds-count p {
     margin-bottom: 0;
-    font-size: 50px;
+    font-size: clamp(15px, 3vw, 50px);
     font-family: Arial, Helvetica, sans-serif;
     display: inline;
-    line-height: 35px;
+    line-height: 1.2;
     text-shadow: 5px 5px black;
 }
 
-.d-masjid-e-usman .english-arabic-date{
+.d-masjid-e-usman .english-arabic-date {
     text-align: right;
-    line-height: 35px;
+    line-height: 1.2;
     text-shadow: 3px 2px black;
     padding: 20px 0 0 0;
 }
 
-.d-masjid-e-usman .english-arabic-date p{
+.d-masjid-e-usman .english-arabic-date p {
     color: #fff;
     margin-bottom: 0;
 }
 
-.d-masjid-e-usman .english-date{
-    font-size: 33px;
+.d-masjid-e-usman .english-date {
+    font-size: clamp(12px, 2vw, 33px);
 }
 
-.d-masjid-e-usman .hijriDate{
-    font-size: 32px;
+.d-masjid-e-usman .hijriDate {
+    font-size: clamp(12px, 2vw, 32px);
     padding-top: 20px;
     font-style: normal;
     text-align: right;
 }
 
-.d-masjid-e-usman .lmc-heading h3{
+.d-masjid-e-usman .lmc-heading h3 {
     color: #fff;
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 30px;
+    font-size: clamp(12px, 2vw, 30px);
     text-align: right;
     text-shadow: 3px 2px black;
 }
 
-.d-masjid-e-usman .jamah-column{
-    padding-right: 0 ;
+.d-masjid-e-usman .jamah-column {
+    padding-right: 0;
 }
-.d-masjid-e-usman .time-value{
+
+.d-masjid-e-usman .time-value {
     text-align: right;
 }
-.d-masjid-e-usman .jummah{
+
+.d-masjid-e-usman .jummah {
     font-family: "DSDIGI" , sans-serif;
-    font-size: 7vh;
+    font-size: clamp(20px, 5vh, 7vh);
     color: #fff;
     font-weight: bolder;
     margin: 0;
@@ -162,9 +165,10 @@
     text-shadow: 5px 5px black;
     text-align: right;
 }
-.d-masjid-e-usman .time-value h3{
+
+.d-masjid-e-usman .time-value h3 {
     font-family: "DSDIGI" , sans-serif;
-    font-size: 7vh;
+    font-size: clamp(20px, 5vh, 7vh);
     color: #fff;
     font-weight: bolder;
     margin: 0;
@@ -172,56 +176,65 @@
     text-shadow: 5px 5px black;
 }
 
-.d-masjid-e-usman .start-title , .d-masjid-e-usman .fajr-start-time h3 , .d-masjid-e-usman .zuhr-start-time h3 , .d-masjid-e-usman .asr-start-time h3 , .d-masjid-e-usman .maghrib-start-time h3 , .d-masjid-e-usman .esha-start-time h3 , .d-masjid-e-usman .jummah-start-time h3{
+.d-masjid-e-usman .start-title,
+.d-masjid-e-usman .fajr-start-time h3,
+.d-masjid-e-usman .zuhr-start-time h3,
+.d-masjid-e-usman .asr-start-time h3,
+.d-masjid-e-usman .maghrib-start-time h3,
+.d-masjid-e-usman .esha-start-time h3,
+.d-masjid-e-usman .jummah-start-time h3 {
     padding-right: 28px;
     text-align: right;
 }
 
-.d-masjid-e-usman .fajr-jamah-time, .d-masjid-e-usman .zuhr-jamah-time, .d-masjid-e-usman .asr-jamah-time , .d-masjid-e-usman .maghrib-jamah-time, .d-masjid-e-usman .esha-jamah-time , .d-masjid-e-usman .jummah-jamah-time{
+.d-masjid-e-usman .fajr-jamah-time,
+.d-masjid-e-usman .zuhr-jamah-time,
+.d-masjid-e-usman .asr-jamah-time,
+.d-masjid-e-usman .maghrib-jamah-time,
+.d-masjid-e-usman .esha-jamah-time,
+.d-masjid-e-usman .jummah-jamah-time {
     padding-right: 0;
-} 
+}
 
-.d-masjid-e-usman .title-value{
+.d-masjid-e-usman .title-value {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 5vh;
+    font-size: clamp(14px, 4vh, 5vh);
     color: #fff;
     text-shadow: 3px 2px black;
     padding-top: 10px;
-    /* padding: 18px 0 30px 0; */
 }
 
-
-.d-masjid-e-usman .left-main-col-prayernames{
-    border-bottom: 5px solid rgb(194 , 194, 194);
+.d-masjid-e-usman .left-main-col-prayernames {
+    border-bottom: 5px solid rgb(194, 194, 194);
     height: 65%;
 }
 
-.d-masjid-e-usman .left-main-col-sun-times p , .d-masjid-e-usman .left-main-col-sun-times h4{
+.d-masjid-e-usman .left-main-col-sun-times p,
+.d-masjid-e-usman .left-main-col-sun-times h4 {
     color: #fff;
     margin: 0;
     text-shadow: 3px 3px black;
     text-transform: uppercase;
 }
 
-
-.d-masjid-e-usman .left-main-col-sun-times p{
+.d-masjid-e-usman .left-main-col-sun-times p {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 3vh;
+    font-size: clamp(10px, 2vw, 3vh);
     padding-top: 10px;
     letter-spacing: 1px;
 }
 
-.d-masjid-e-usman .left-main-col-sun-times h4{
+.d-masjid-e-usman .left-main-col-sun-times h4 {
     font-family: "DSDIGI" , sans-serif;
-    font-size: 40px;
+    font-size: clamp(18px, 3vw, 40px);
     font-weight: bold;
-    line-height: 5px;
+    line-height: 1.2;
 }
 
-.d-masjid-e-usman .afterlogo-text h1{
+.d-masjid-e-usman .afterlogo-text h1 {
     color: #d7d7d7;
     font-family: "BebasNeueRegular";
-    font-size: 65px;
+    font-size: clamp(24px, 5vw, 65px);
     padding: 25px 0 0 0;
     text-align: center;
 }
@@ -232,411 +245,41 @@
     height: 100%;
 }
 
-.d-masjid-e-usman  .nextPrayer h3, .nextPrayer .title, .d-masjid-e-usman .nextPrayer .dsJumuah {
-    color: rgb(86,247,79);
-}
-.d-masjid-e-usman  .left-main-col-sun-times h4{
+.d-masjid-e-usman .nextPrayer h3,
+.d-masjid-e-usman .nextPrayer .title,
+.d-masjid-e-usman .nextPrayer .dsJumuah {
     color: rgb(86,247,79);
 }
 
-.d-masjid-e-usman .mobile-logo-row{
+.d-masjid-e-usman .left-main-col-sun-times h4 {
+    color: rgb(86,247,79);
+}
+
+.d-masjid-e-usman .mobile-logo-row {
     display: none;
 }
-.d-masjid-e-usman .isha-jamah-time{
+
+.d-masjid-e-usman .isha-jamah-time {
     padding-right: 0;
 }
-.d-masjid-e-usman .isha-start-time{
+
+.d-masjid-e-usman .isha-start-time {
     position: relative;
     right: 25px;
 }
 
+/* Mobile adjustments */
+@media (max-width: 768px) {
+    .d-masjid-e-usman {
+        height: auto;
+        min-height: 100vh;
+    }
 
-/* FIX FOR LOW RESOLUTION DEVICE */
+    .d-masjid-e-usman .left-main-column {
+        padding: 15px;
+    }
 
-@media(max-width : 1000px){
-    .d-masjid-e-usman .digital-clock{
-        padding: 0 28px 0 0;
-        margin: 0;
-    }
-    .d-masjid-e-usman .digital-clock h2{
-        line-height: 19vh;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 16px;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 20px;
-    }
-    .d-masjid-e-usman .seconds-count p {
-        font-size: 35px;
-    }
-    .d-masjid-e-usman .seconds-count h4 {
-        font-size: 43px;
-    }
-    .d-masjid-e-usman .lmc-heading h3 {
-        font-size: 22px;
-    }
-    .d-masjid-e-usman .time-value h3{
-        font-size: 6vh;
-    }
-    .d-masjid-e-usman .title-value{
-        font-size: 4vh;
-    }
-    .d-masjid-e-usman .left-main-col-prayernames{
-        height: 60%;
-    }
-    .d-masjid-e-usman .banner-section{
-        height: 79%;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 2vh;
-        letter-spacing: 0;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 27px;
-    }
-    .d-masjid-e-usman .logo-section img{
-        max-width: 100px;
-    }
-    .d-masjid-e-usman .afterlogo-text h1{
-        font-size: 45px;
-    }
-}
-
-
-
-
-/* MOBILE VERSION DESIGN */
-
-@media(max-width : 768px){
-    .d-masjid-e-usman{
-        height: 200vh;
-    }
-    .d-masjid-e-usman .left-main-column{
-        padding: 20px 45px;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime {
-        height: 12%;
-    }
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 14vh;
-    }
-    .d-masjid-e-usman .seconds-count h4{
-        font-size: 55px;
-    }
-    .d-masjid-e-usman .seconds-count p{
-        font-size: 45px;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 25px;
-        text-shadow: 2px 2px #252424;
-
-    }
-    .d-masjid-e-usman .masjid-name-logo{
-        display: none;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 27px;
-        text-shadow: 2px 2px #252424;
-
-    }
-    .d-masjid-e-usman .lmc-heading h3{
-        font-size: 27px;
-    }
-    .d-masjid-e-usman .time-value h3{
-        font-size: 6vh;
-    }
-    .d-masjid-e-usman .title-value{
-        font-size: 4vh;
-    }
-    .d-masjid-e-usman .left-main-col-prayernames{
-        height: 37%;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 17px;
-        text-shadow: 1px 1px #252424;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 30px;
-        text-shadow: 1px 1px #252424;
-    } 
-    .d-masjid-e-usman .left-main-column{
-        position: absolute;
-    }
-    .d-masjid-e-usman .right-main-column{
-        position: relative;
-        top: 650px;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime .col-4{
-        width: 30.333333%;
-    }
     .d-masjid-e-usman .banner-section {
         height: 45%;
     }
-    .d-masjid-e-usman .mobile-logo-row {
-    display: block;
-    }
-    .d-masjid-e-usman .mobile-logo-column img{
-        height: 100px;
-    }
 }
-
-@media(max-width:680px){
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 13vh;
-    }
-    .d-masjid-e-usman .seconds-count h4{
-        font-size: 50px;
-    }
-    .d-masjid-e-usman .seconds-count p{
-        font-size: 40px;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 20px;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 20px;
-    }
-    .d-masjid-e-usman .lmc-heading h3{
-        font-size: 25px;
-    }
-    .d-masjid-e-usman .time-value h3{
-        font-size: 5vh;
-        text-shadow: 2px 2px #252424;
-    }
-    .d-masjid-e-usman .title-value{
-        font-size: 3vh;
-        text-shadow: 2px 2px #252424;
-    }
-}
-
-@media(max-width : 600px){
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 11vh;
-    }
-}
-
-@media(max-width: 577px){
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 10vh;
-        text-shadow: 3px 3px black;
-    }
-    .d-masjid-e-usman .seconds-count{
-        padding-top: 15px;
-    }
-    .d-masjid-e-usman .seconds-count h4{
-        font-size: 35px;
-        text-shadow: 2px 2px black;
-    }
-    .d-masjid-e-usman .seconds-count p{
-        font-size: 27px;
-        line-height: 0;
-        text-shadow: 2px 2px black;
-
-    }
-    .d-masjid-e-usman .lmc-heading h3{
-        font-size: 22px;
-        text-shadow: 2px 2px #252424;
-    }
-    .d-masjid-e-usman .title-value{
-        font-size: 3vh;
-    }
-    .d-masjid-e-usman .left-main-col-prayernames{
-        height: 37%;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 15px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 25px;
-    } 
-    .d-masjid-e-usman .left-main-column{
-        position: absolute;
-    }
-    .d-masjid-e-usman .right-main-column{
-        position: relative;
-        top: 600px;
-    }
-}
-
-@media(max-width : 500px){
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 8vh;
-    }
-    .d-masjid-e-usman .seconds-count{
-        padding-top: 28px;
-        position: relative;
-        right: 20px;
-    }
-    .d-masjid-e-usman .seconds-count h4{
-        font-size: 25px;
-        line-height: 46px;
-    }
-    .d-masjid-e-usman .seconds-count p{
-        font-size: 20px;
-        line-height: 0;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 20px;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 20px;
-    }
-    .d-masjid-e-usman .english-arabic-date {
-        line-height: 10px;
-        padding: 27px 0 0 0;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 10px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 20px;
-    } 
-    .d-masjid-e-usman .banner-section {
-        height: 40%;
-    }
-    .d-masjid-e-usman{
-        height: 120vh;
-    }
-     .d-masjid-e-usman .jummah-jamah-time {
-        line-height: 0;
-        font-size: 3vh;
-        text-shadow: 2px 2px #252424;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime{
-        height: 15vh;        
-    }
-    .d-masjid-e-usman .seconds-count h4{
-        padding-left: 0;
-    }
-    .d-masjid-e-usman .title-value{
-        padding-top: 4px;
-    }
-    .d-masjid-e-usman .height-100{
-        height: auto;
-    }
-}
-
-@media(max-width : 460px){
-    .d-masjid-e-usman .digital-clock h2{
-        font-size: 5vh;
-        line-height: 10vh;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime .col-4 {
-        width: 29.333333%;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime .col-6{
-        width: 53%;
-    }
-    .d-masjid-e-usman .english-arabic-date {
-        line-height: 14px;
-    }
-    .d-masjid-e-usman .seconds-count h4 {
-        font-size: 21px;
-        line-height: 10px;
-    }
-    .d-masjid-e-usman .seconds-count p{
-        font-size: 18px;
-    }
-    .d-masjid-e-usman .seconds-count{
-        padding-top: 30px;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 15px;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 15px;
-        padding-top: 12px;
-    }
-    .d-masjid-e-usman .lmc-heading h3{
-        font-size: 15px;
-    }
-    .d-masjid-e-usman .time-value h3{
-        font-size: 3vh;
-    }
-    .d-masjid-e-usman .title-value{
-        font-size: 2vh;
-    }
-    .d-masjid-e-usman .jummah-jamah-time {
-        line-height: 36px;
-        font-size: 3vh;
-    }
-    .d-masjid-e-usman .right-main-column{
-        top: 430px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 15px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 25px;
-    } 
-    .d-masjid-e-usman .title-value{
-        padding-left: 4px;
-    }
-    .d-masjid-e-usman .banner-section {
-        height: 40%;
-        padding-top: 0;
-    }
-    .d-masjid-e-usman{
-        height: 108vh;
-    }
-    .d-masjid-e-usman .mobile-logo-column img{
-        height: 100px;
-        position: relative;
-        top: 20px;
-    }
-    .d-masjid-e-usman .left-main-col-dateandtime {
-        height: 10vh;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times .sub-sadiq-title{
-        font-size: 10px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times {
-        line-height: 12px;
-    }
-    .d-masjid-e-usman .left-main-col-prayernames {
-        padding-top: 10px;
-    }
-}
-
-@media(max-width : 400px){
-    .d-masjid-e-usman .english-arabic-date {
-        line-height: 10px;
-    }
-    .d-masjid-e-usman .english-date {
-        font-size: 13px;
-    }
-    .d-masjid-e-usman .hijriDate {
-        font-size: 13px;
-        padding-top: 9px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times p{
-        font-size: 13px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times h4{
-        font-size: 20px;
-    } 
-    .d-masjid-e-usman .lmc-heading h3 {
-        font-size: 13px;
-    }
-    .d-masjid-e-usman .left-main-col-sun-times .sub-sadiq-title{
-        font-size: 9px;
-   }
-   .d-masjid-e-usman .left-main-col-dateandtime {
-        height: 9vh;
-    }
-    .d-masjid-e-usman .right-main-column{
-        top: 400px;
-    }
-    .d-masjid-e-usman .digital-clock h2#hours{
-        min-width: 50%;
-        max-width: 40%;
-    }
-}
-
-@media(max-width : 390px){
-    .d-masjid-e-usman .mobile-logo-column img{
-        left: 95px;
-    }
-}
-

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -272,21 +272,12 @@
 }
 
 .d-masjid-e-usman .start-title,
-.d-masjid-e-usman .fajr-start-time h3,
-.d-masjid-e-usman .zuhr-start-time h3,
-.d-masjid-e-usman .asr-start-time h3,
-.d-masjid-e-usman .maghrib-start-time h3,
-.d-masjid-e-usman .esha-start-time h3,
-.d-masjid-e-usman .jummah-start-time h3 {
+.d-masjid-e-usman .prayer-start-time h3 {
     padding-right: 28px;
     text-align: right;
 }
 
-.d-masjid-e-usman .fajr-jamah-time,
-.d-masjid-e-usman .zuhr-jamah-time,
-.d-masjid-e-usman .asr-jamah-time,
-.d-masjid-e-usman .maghrib-jamah-time,
-.d-masjid-e-usman .esha-jamah-time,
+.d-masjid-e-usman .prayer-jamah-time,
 .d-masjid-e-usman .jummah-jamah-time {
     padding-right: 0;
 }
@@ -497,13 +488,12 @@
     display: flex;
 }
 
-.d-masjid-e-usman .isha-jamah-time {
-    padding-right: 0;
+.d-masjid-e-usman .prayer-start-time {
+    position: relative;
 }
 
-.d-masjid-e-usman .isha-start-time {
-    position: relative;
-    right: 25px;
+.d-masjid-e-usman .prayer-jamah-time {
+    padding-right: 0;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -544,17 +534,8 @@
     }
 
     .d-masjid-e-usman .start-title,
-    .d-masjid-e-usman .fajr-start-time h3,
-    .d-masjid-e-usman .zuhr-start-time h3,
-    .d-masjid-e-usman .asr-start-time h3,
-    .d-masjid-e-usman .maghrib-start-time h3,
-    .d-masjid-e-usman .esha-start-time h3,
-    .d-masjid-e-usman .jummah-start-time h3 {
+    .d-masjid-e-usman .prayer-start-time h3 {
         padding-right: 12px;
-    }
-
-    .d-masjid-e-usman .isha-start-time {
-        right: 12px;
     }
 }
 
@@ -711,7 +692,7 @@
 
     .d-masjid-e-usman .lmc-heading h3 {
         font-size: 12px;
-        padding-right: 4px;
+        padding-right: 50px;
         margin-bottom: 0;
         letter-spacing: 0.5px;
         color: rgba(255,255,255,0.7);
@@ -738,7 +719,7 @@
     /* Prayer name */
     .d-masjid-e-usman .title-value {
         padding-top: 0;
-        padding-left: 4px;
+        padding-left: 33px;
         line-height: 1.2;
     }
 
@@ -752,22 +733,15 @@
 
     /* Remove desktop fixed padding on start times */
     .d-masjid-e-usman .start-title,
-    .d-masjid-e-usman .fajr-start-time h3,
-    .d-masjid-e-usman .zuhr-start-time h3,
-    .d-masjid-e-usman .asr-start-time h3,
-    .d-masjid-e-usman .maghrib-start-time h3,
-    .d-masjid-e-usman .esha-start-time h3,
-    .d-masjid-e-usman .jummah-start-time h3 {
-        padding-right: 4px;
-    }
-
-    .d-masjid-e-usman .isha-start-time {
-        right: 0;
+    .d-masjid-e-usman .prayer-start-time,
+    .d-masjid-e-usman .prayer-start-time h3 {
         position: static;
+        padding-right: 33px;
     }
 
+    .d-masjid-e-usman .prayer-jamah-time,
     .d-masjid-e-usman .jummah-jamah-time {
-        padding-right: 4px;
+        padding-right: 50px;
     }
 
     /* ── Sun times bar — 2×2 grid on very small screens, row on normal ── */

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -77,7 +77,7 @@
 }
 
 .d-masjid-e-usman .digital-clock h2 {
-    font-size: clamp(40px, 10vw, 120px);
+    font-size: clamp(48px, 12vw, 120px);
     font-weight: 900;
     display: inline-block;
     text-shadow: 7px 7px black;
@@ -112,14 +112,23 @@
 }
 
 .d-masjid-e-usman .seconds-count h4 {
-    font-family: "DSDIGI", sans-serif;
-    font-size: clamp(24px, 5vw, 45px);
+    font-family: "DSDIGI" , sans-serif;
+    font-size: clamp(28px, 6vw, 45px);
     font-weight: 600;
     margin-bottom: 0;
     display: block;
     line-height: 1.1;
     text-shadow: 5px 5px black;
     padding-left: 9px;
+}
+
+.d-masjid-e-usman .seconds-count p {
+    margin-bottom: 0;
+    font-size: clamp(20px, 4vw, 35px);
+    font-family: Arial, Helvetica, sans-serif;
+    display: inline;
+    line-height: 1.2;
+    text-shadow: 5px 5px black;
 }
 
 .d-masjid-e-usman .seconds-count p {
@@ -146,7 +155,14 @@
 }
 
 .d-masjid-e-usman .english-date {
-    font-size: clamp(14px, 3vw, 33px);
+    font-size: clamp(22px, 5vw, 33px);
+}
+
+.d-masjid-e-usman .hijriDate {
+    font-size: clamp(22px, 5vw, 32px);
+    padding-top: 20px;
+    font-style: normal;
+    text-align: right;
 }
 
 .d-masjid-e-usman .hijriDate {
@@ -161,7 +177,7 @@
 .d-masjid-e-usman .lmc-heading h3 {
     color: #fff;
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(18px, 3vw, 30px);
+    font-size: clamp(22px, 4vw, 30px);
     text-align: right;
     text-shadow: 3px 2px black;
 }
@@ -189,7 +205,7 @@
 
 .d-masjid-e-usman .time-value h3 {
     font-family: "DSDIGI", sans-serif;
-    font-size: clamp(24px, 5vh, 7vh);
+    font-size: clamp(28px, 6vh, 7vh);
     color: #fff;
     font-weight: bolder;
     margin: 0;
@@ -219,7 +235,7 @@
 
 .d-masjid-e-usman .title-value {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(18px, 4vh, 5vh);
+    font-size: clamp(22px, 5vh, 5vh);
     color: #fff;
     text-shadow: 3px 2px black;
     padding-top: 10px;
@@ -242,14 +258,14 @@
 
 .d-masjid-e-usman .left-main-col-sun-times p {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(9px, 1.5vw, 3vh);
+    font-size: clamp(12px, 2vw, 3vh);
     padding-top: 10px;
     letter-spacing: 1px;
 }
 
 .d-masjid-e-usman .left-main-col-sun-times h4 {
     font-family: "DSDIGI", sans-serif;
-    font-size: clamp(14px, 2.5vw, 40px);
+    font-size: clamp(18px, 3vw, 40px);
     font-weight: bold;
     line-height: 1.2;
     color: rgb(86,247,79);
@@ -309,7 +325,7 @@
 .d-masjid-e-usman .afterlogo-text h1 {
     color: #d7d7d7;
     font-family: "BebasNeueRegular";
-    font-size: clamp(24px, 5vw, 65px);
+    font-size: clamp(28px, 6vw, 65px);
     padding: 25px 0 0 0;
     text-align: center;
 }

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -5,58 +5,98 @@
 
 @font-face {
     font-family: "BebasNeueRegular";
-    src: local('BebasNeueRegula'), url('./BebasNeue-Regular.ttf') format('truetype');
+    src: local('BebasNeueRegular'), url('./BebasNeue-Regular.ttf') format('truetype');
 }
 
 .usman-body {
     padding: 0;
     margin: 0;
     background-image: linear-gradient(to left top, black, rgb(1,48,42), rgb(6,99,88), rgb(6,99,88), rgb(1,48,42), black);
-    height: 100%;
+    height: 100vh;
     width: 100%;
 }
 
 .d-masjid-e-usman {
     height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.d-masjid-e-usman .row {
+    flex: 1;
+    display: flex;
+    margin: 0;
 }
 
 .d-masjid-e-usman .left-main-column {
     padding-left: 50px;
+    padding-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .d-masjid-e-usman .left-main-col-dateandtime {
     border-bottom: 5px solid rgb(194, 194, 194);
     text-align: left;
-    height: 20%;
+    flex: 0 0 auto;
+    min-height: 120px;
 }
 
 .d-masjid-e-usman .left-main-col-prayernames {
-    height: 80%;
+    flex: 1;
     padding-top: 17px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
 }
 
+.d-masjid-e-usman .prayernames-column {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    justify-content: space-evenly;
+}
+
+.d-masjid-e-usman .prayernames-column .row {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    min-height: 0;
+}
+
+/* ─── DIGITAL CLOCK ─────────────────────────────────────────────────── */
+
 .d-masjid-e-usman .digital-clock {
-    font-family: "DSDIGI" , sans-serif;
+    font-family: "DSDIGI", sans-serif;
     color: rgb(86,247,79);
     display: flex;
+    align-items: center;
 }
 
 .d-masjid-e-usman .digital-clock h2 {
-    font-size: clamp(20px, 7vw, 120px);
-    font-weight: 800;
+    font-size: clamp(40px, 10vw, 120px);
+    font-weight: 900;
     display: inline-block;
     text-shadow: 7px 7px black;
     margin-left: -10px;
+    -webkit-text-stroke: 2px rgb(86,247,79);
+    margin-bottom: 0;
 }
 
 .d-masjid-e-usman .digital-clock h2#hours {
     min-width: 40%;
     max-width: 40%;
+    margin-right: 30px;
+    text-align: right;
 }
 
 .d-masjid-e-usman .digital-clock h2#min {
     min-width: 60%;
     max-width: 60%;
+    margin-left: 5px;
 }
 
 .d-masjid-e-usman .digital-clock h2#colon {
@@ -64,41 +104,16 @@
     max-width: 10%;
 }
 
-.d-masjid-e-usman .digital-clock h2#hours {
-    margin-right: 30px;
-    text-align: right;
-}
-
-.d-masjid-e-usman .digital-clock h2#min {
-    margin-left: 5px;
-}
-
-.d-masjid-e-usman .banner-section {
-    margin: 0;
-    height: 85%;
-    padding: 25px 20px 0 20px;
-}
-
-.d-masjid-e-usman .banner-section img {
-    height: 100%;
-    width: 100%;
-    border: 1px solid rgb(255, 255, 255);
-}
-
-.d-masjid-e-usman .logo-section img {
-    height: 100%;
-    padding: 10px 0 0 20px;
-    max-width: 100px;
-}
+/* ─── SECONDS / AM-PM ───────────────────────────────────────────────── */
 
 .d-masjid-e-usman .seconds-count {
     color: rgb(86,247,79);
-    padding-top: 10px;
+    padding-top: 30px;
 }
 
 .d-masjid-e-usman .seconds-count h4 {
-    font-family: "DSDIGI" , sans-serif;
-    font-size: clamp(20px, 4vw, 60px);
+    font-family: "DSDIGI", sans-serif;
+    font-size: clamp(24px, 5vw, 45px);
     font-weight: 600;
     margin-bottom: 0;
     display: block;
@@ -109,12 +124,14 @@
 
 .d-masjid-e-usman .seconds-count p {
     margin-bottom: 0;
-    font-size: clamp(15px, 3vw, 50px);
+    font-size: clamp(16px, 3vw, 35px);
     font-family: Arial, Helvetica, sans-serif;
     display: inline;
     line-height: 1.2;
     text-shadow: 5px 5px black;
 }
+
+/* ─── DATE ──────────────────────────────────────────────────────────── */
 
 .d-masjid-e-usman .english-arabic-date {
     text-align: right;
@@ -129,20 +146,22 @@
 }
 
 .d-masjid-e-usman .english-date {
-    font-size: clamp(12px, 2vw, 33px);
+    font-size: clamp(14px, 3vw, 33px);
 }
 
 .d-masjid-e-usman .hijriDate {
-    font-size: clamp(12px, 2vw, 32px);
+    font-size: clamp(14px, 3vw, 32px);
     padding-top: 20px;
     font-style: normal;
     text-align: right;
 }
 
+/* ─── PRAYER TABLE HEADINGS ─────────────────────────────────────────── */
+
 .d-masjid-e-usman .lmc-heading h3 {
     color: #fff;
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(12px, 2vw, 30px);
+    font-size: clamp(18px, 3vw, 30px);
     text-align: right;
     text-shadow: 3px 2px black;
 }
@@ -155,9 +174,11 @@
     text-align: right;
 }
 
+/* ─── PRAYER TIME VALUES ────────────────────────────────────────────── */
+
 .d-masjid-e-usman .jummah {
-    font-family: "DSDIGI" , sans-serif;
-    font-size: clamp(20px, 5vh, 7vh);
+    font-family: "DSDIGI", sans-serif;
+    font-size: clamp(16px, 4vh, 7vh);
     color: #fff;
     font-weight: bolder;
     margin: 0;
@@ -167,8 +188,8 @@
 }
 
 .d-masjid-e-usman .time-value h3 {
-    font-family: "DSDIGI" , sans-serif;
-    font-size: clamp(20px, 5vh, 7vh);
+    font-family: "DSDIGI", sans-serif;
+    font-size: clamp(24px, 5vh, 7vh);
     color: #fff;
     font-weight: bolder;
     margin: 0;
@@ -198,7 +219,7 @@
 
 .d-masjid-e-usman .title-value {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(14px, 4vh, 5vh);
+    font-size: clamp(18px, 4vh, 5vh);
     color: #fff;
     text-shadow: 3px 2px black;
     padding-top: 10px;
@@ -208,6 +229,8 @@
     border-bottom: 5px solid rgb(194, 194, 194);
     height: 65%;
 }
+
+/* ─── SUN TIMES ─────────────────────────────────────────────────────── */
 
 .d-masjid-e-usman .left-main-col-sun-times p,
 .d-masjid-e-usman .left-main-col-sun-times h4 {
@@ -219,16 +242,68 @@
 
 .d-masjid-e-usman .left-main-col-sun-times p {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: clamp(10px, 2vw, 3vh);
+    font-size: clamp(9px, 1.5vw, 3vh);
     padding-top: 10px;
     letter-spacing: 1px;
 }
 
 .d-masjid-e-usman .left-main-col-sun-times h4 {
-    font-family: "DSDIGI" , sans-serif;
-    font-size: clamp(18px, 3vw, 40px);
+    font-family: "DSDIGI", sans-serif;
+    font-size: clamp(14px, 2.5vw, 40px);
     font-weight: bold;
     line-height: 1.2;
+    color: rgb(86,247,79);
+}
+
+.d-masjid-e-usman .left-main-col-sun-times {
+    flex: 0 0 auto;
+    min-height: 80px;
+    display: flex;
+    align-items: center;
+    padding-bottom: 15px;
+}
+
+.d-masjid-e-usman .left-main-col-sun-times .row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+}
+
+/* ─── RIGHT COLUMN ──────────────────────────────────────────────────── */
+
+.d-masjid-e-usman .banner-section {
+    margin: 0;
+    height: 85%;
+    padding: 25px 20px 0 20px;
+}
+
+.d-masjid-e-usman .banner-section img {
+    height: 100%;
+    width: 100%;
+    border: 1px solid rgb(255, 255, 255);
+}
+
+.d-masjid-e-usman .logo-section img {
+    height: 100%;
+    padding: 10px 0 0 20px;
+    max-width: 100px;
+}
+
+.d-masjid-e-usman .mosque-info-overlay {
+    display: flex;
+    align-items: center;
+    padding: 10px 0;
+}
+
+.d-masjid-e-usman .logo-section {
+    flex: 0 0 auto;
+    width: auto;
+}
+
+.d-masjid-e-usman .afterlogo-text {
+    flex: 1;
+    width: auto;
 }
 
 .d-masjid-e-usman .afterlogo-text h1 {
@@ -245,15 +320,15 @@
     height: 100%;
 }
 
+/* ─── NEXT PRAYER HIGHLIGHT ─────────────────────────────────────────── */
+
 .d-masjid-e-usman .nextPrayer h3,
 .d-masjid-e-usman .nextPrayer .title,
 .d-masjid-e-usman .nextPrayer .dsJumuah {
     color: rgb(86,247,79);
 }
 
-.d-masjid-e-usman .left-main-col-sun-times h4 {
-    color: rgb(86,247,79);
-}
+/* ─── MISC ──────────────────────────────────────────────────────────── */
 
 .d-masjid-e-usman .mobile-logo-row {
     display: none;
@@ -268,18 +343,376 @@
     right: 25px;
 }
 
-/* Mobile adjustments */
-@media (max-width: 768px) {
+/* ═══════════════════════════════════════════════════════════════════════
+   TABLET  (≤ 991px)
+   Two-column layout starts to get cramped — tighten spacing
+═══════════════════════════════════════════════════════════════════════ */
+@media (max-width: 991px) {
     .d-masjid-e-usman {
         height: auto;
         min-height: 100vh;
     }
 
     .d-masjid-e-usman .left-main-column {
-        padding: 15px;
+        padding-left: 20px;
+        padding-right: 10px;
+    }
+
+    .d-masjid-e-usman .digital-clock h2 {
+        font-size: clamp(32px, 8vw, 80px);
+    }
+
+    .d-masjid-e-usman .seconds-count h4 {
+        font-size: clamp(20px, 4vw, 36px);
+    }
+
+    .d-masjid-e-usman .title-value {
+        font-size: clamp(11px, 2.2vh, 4vh);
+    }
+
+    .d-masjid-e-usman .time-value h3,
+    .d-masjid-e-usman .jummah {
+        font-size: clamp(13px, 3.5vh, 5.5vh);
     }
 
     .d-masjid-e-usman .banner-section {
-        height: 45%;
+        height: 60%;
+        padding: 15px 10px 0 10px;
+    }
+
+    .d-masjid-e-usman .start-title,
+    .d-masjid-e-usman .fajr-start-time h3,
+    .d-masjid-e-usman .zuhr-start-time h3,
+    .d-masjid-e-usman .asr-start-time h3,
+    .d-masjid-e-usman .maghrib-start-time h3,
+    .d-masjid-e-usman .esha-start-time h3,
+    .d-masjid-e-usman .jummah-start-time h3 {
+        padding-right: 12px;
+    }
+
+    .d-masjid-e-usman .isha-start-time {
+        right: 12px;
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   MOBILE  (≤ 767px)
+═══════════════════════════════════════════════════════════════════════ */
+@media (max-width: 767px) {
+
+    /* ── Layout ── */
+    .d-masjid-e-usman {
+        height: auto;
+    }
+
+    /* Mobile logo — compact header strip */
+    .d-masjid-e-usman .mobile-logo-row {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(86,247,79,0.3);
+        background: rgba(0,0,0,0.25);
+    }
+
+    .d-masjid-e-usman .mobile-logo-row img {
+        max-height: 44px;
+        width: auto;
+    }
+
+    .d-masjid-e-usman .left-main-column {
+        padding: 0 10px 4px;
+    }
+
+    /* ── Date/time row — tighter, vertically centered ── */
+    .d-masjid-e-usman .left-main-col-dateandtime {
+        height: auto;
+        padding: 6px 0 8px;
+        border-bottom: 2px solid rgba(194,194,194,0.5);
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    /* Clock digits */
+    .d-masjid-e-usman .digital-clock {
+        align-items: center;
+        padding: 0;
+    }
+
+    .d-masjid-e-usman .digital-clock h2 {
+        font-size: 52px;
+        text-shadow: 3px 3px black;
+        -webkit-text-stroke: 1px rgb(86,247,79);
+        margin: 0;
+        line-height: 1;
+    }
+
+    .d-masjid-e-usman .digital-clock h2#hours {
+        min-width: unset;
+        max-width: unset;
+        margin-right: 0;
+        text-align: left;
+    }
+
+    .d-masjid-e-usman .digital-clock h2#colon {
+        min-width: unset;
+        max-width: unset;
+        margin: 0 3px;
+        line-height: 0.9;
+    }
+
+    .d-masjid-e-usman .digital-clock h2#min {
+        min-width: unset;
+        max-width: unset;
+        margin-left: 0;
+    }
+
+    /* Seconds + AM/PM — stacked neatly beside clock */
+    .d-masjid-e-usman .seconds-count {
+        padding-top: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: 6px;
+    }
+
+    .d-masjid-e-usman .seconds-count h4 {
+        font-size: 26px;
+        padding-left: 0;
+        line-height: 1;
+        text-shadow: 3px 3px black;
+    }
+
+    .d-masjid-e-usman .seconds-count p {
+        font-size: 16px;
+        line-height: 1.1;
+        text-shadow: 3px 3px black;
+    }
+
+    /* Date — right-aligned, both lines visible */
+    .d-masjid-e-usman .english-arabic-date {
+        padding: 4px 2px 0 0;
+        text-align: right;
+    }
+
+    .d-masjid-e-usman .english-date {
+        font-size: 13px;
+        line-height: 1.3;
+    }
+
+    .d-masjid-e-usman .hijriDate {
+        font-size: 13px;
+        padding-top: 2px;
+        line-height: 1.3;
+    }
+
+    /* ── Prayer table ── */
+    .d-masjid-e-usman .left-main-col-prayernames {
+        height: auto;
+        padding-top: 4px;
+        border-bottom: 2px solid rgba(194,194,194,0.5);
+    }
+
+    /* Column headers */
+    .d-masjid-e-usman .lmc-heading {
+        margin-bottom: 2px;
+    }
+
+    .d-masjid-e-usman .lmc-heading h3 {
+        font-size: 12px;
+        padding-right: 4px;
+        margin-bottom: 0;
+        letter-spacing: 0.5px;
+        color: rgba(255,255,255,0.7);
+    }
+
+    /* Prayer rows — alternating subtle background for readability */
+    .d-masjid-e-usman .fajr-section,
+    .d-masjid-e-usman .zuhr-section,
+    .d-masjid-e-usman .asr-section,
+    .d-masjid-e-usman .maghrib-section,
+    .d-masjid-e-usman .isha-section,
+    .d-masjid-e-usman .jummah-section {
+        padding: 5px 0;
+        align-items: center;
+        border-radius: 4px;
+        margin: 1px 0;
+    }
+
+    .d-masjid-e-usman .fajr-section,
+    .d-masjid-e-usman .asr-section,
+    .d-masjid-e-usman .isha-section {
+        background: rgba(255,255,255,0.04);
+    }
+
+    /* Prayer name */
+    .d-masjid-e-usman .title-value {
+        font-size: 16px;
+        font-weight: bold;
+        padding-top: 0;
+        padding-left: 4px;
+        line-height: 1.2;
+    }
+
+    /* Time values */
+    .d-masjid-e-usman .time-value h3,
+    .d-masjid-e-usman .jummah {
+        font-size: 18px;
+        text-shadow: 2px 2px black;
+        line-height: 1.2;
+    }
+
+    /* Remove desktop fixed padding on start times */
+    .d-masjid-e-usman .start-title,
+    .d-masjid-e-usman .fajr-start-time h3,
+    .d-masjid-e-usman .zuhr-start-time h3,
+    .d-masjid-e-usman .asr-start-time h3,
+    .d-masjid-e-usman .maghrib-start-time h3,
+    .d-masjid-e-usman .esha-start-time h3,
+    .d-masjid-e-usman .jummah-start-time h3 {
+        padding-right: 4px;
+    }
+
+    .d-masjid-e-usman .isha-start-time {
+        right: 0;
+        position: static;
+    }
+
+    .d-masjid-e-usman .jummah-jamah-time {
+        padding-right: 4px;
+    }
+
+    /* ── Sun times bar — 2×2 grid on very small screens, row on normal ── */
+    .d-masjid-e-usman .left-main-col-sun-times {
+        padding: 8px 4px 10px;
+        border-top: none;
+    }
+
+    .d-masjid-e-usman .left-main-col-sun-times .col-md-3 {
+        padding: 0 4px;
+        text-align: center;
+    }
+
+    .d-masjid-e-usman .left-main-col-sun-times p {
+        font-size: 9px;
+        letter-spacing: 0;
+        padding-top: 4px;
+        line-height: 1.2;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .d-masjid-e-usman .left-main-col-sun-times h4 {
+        font-size: 17px;
+        line-height: 1.2;
+    }
+
+    /* ── Right column (banner + mosque name) ── */
+    .d-masjid-e-usman .right-main-column {
+        padding: 0 10px 16px;
+    }
+
+    .d-masjid-e-usman .banner-section {
+        height: 260px;
+        padding: 8px 0 0;
+    }
+
+    .d-masjid-e-usman .banner-section .carousel,
+    .d-masjid-e-usman .banner-section .carousel-inner {
+        height: 100%;
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    .d-masjid-e-usman .banner-section img {
+        object-fit: cover;
+        border-radius: 6px;
+    }
+
+    /* Mosque name footer - side by side on mobile */
+    .d-masjid-e-usman .mosque-info-overlay {
+        display: flex !important;
+        flex-direction: row !important;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 6px 0 4px;
+        border-top: 1px solid rgba(86,247,79,0.2);
+        margin-top: 4px;
+        width: 100%;
+    }
+
+    .d-masjid-e-usman .mosque-info-overlay > div {
+        display: flex !important;
+        flex-direction: row !important;
+    }
+
+    .d-masjid-e-usman .logo-section {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 auto;
+        width: auto !important;
+    }
+
+    .d-masjid-e-usman .logo-section img {
+        max-width: 40px;
+        max-height: 40px;
+        padding: 0;
+        object-fit: contain;
+    }
+
+    .d-masjid-e-usman .afterlogo-text {
+        flex: 1 1 auto !important;
+        width: auto !important;
+    }
+
+    .d-masjid-e-usman .afterlogo-text h1 {
+        font-size: clamp(14px, 4vw, 20px);
+        padding: 6px 0 0;
+        text-align: left;
+        line-height: 1.1;
+        color: #e0e0e0;
+        margin: 0;
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   SMALL MOBILE  (≤ 380px)
+═══════════════════════════════════════════════════════════════════════ */
+@media (max-width: 380px) {
+    .d-masjid-e-usman .digital-clock h2 {
+        font-size: 40px;
+    }
+
+    .d-masjid-e-usman .seconds-count h4 {
+        font-size: 20px;
+    }
+
+    .d-masjid-e-usman .title-value {
+        font-size: 14px;
+    }
+
+    .d-masjid-e-usman .time-value h3,
+    .d-masjid-e-usman .jummah {
+        font-size: 15px;
+    }
+
+    .d-masjid-e-usman .left-main-col-sun-times p {
+        font-size: 8px;
+    }
+
+    .d-masjid-e-usman .left-main-col-sun-times h4 {
+        font-size: 14px;
+    }
+
+    .d-masjid-e-usman .banner-section {
+        height: 200px;
+    }
+
+    .d-masjid-e-usman .english-date,
+    .d-masjid-e-usman .hijriDate {
+        font-size: 11px;
     }
 }

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -23,10 +23,10 @@
     overflow: hidden;
 }
 
-/* ─── TOP HEADER ───────────────────────────────────────────────────── */
+/* ─── TOP HEADER - Mobile only ───────────────────────────────── */
 .d-masjid-e-usman .top-header-row {
     flex: 0 0 auto;
-    display: flex;
+    display: none;
     align-items: center;
     padding: 10px 20px;
     background: rgba(0,0,0,0.3);
@@ -55,6 +55,22 @@
     font-size: clamp(28px, 5vw, 48px);
     margin: 0;
     text-shadow: 3px 3px black;
+}
+
+/* Hide desktop bottom overlay on mobile */
+.d-masjid-e-usman .mosque-info-overlay.desktop-only {
+    display: flex;
+}
+
+/* Mobile only - show top, hide bottom */
+@media (max-width: 767px) {
+    .d-masjid-e-usman .top-header-row {
+        display: flex;
+    }
+    
+    .d-masjid-e-usman .mosque-info-overlay.desktop-only {
+        display: none;
+    }
 }
 
 .d-masjid-e-usman .row {

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -23,7 +23,7 @@
     overflow: hidden;
 }
 
-/* ─── TOP HEADER - Mobile only ───────────────────────────────── */
+/* ─── TOP HEADER - Hidden by default (desktop) ──────────────────────── */
 .d-masjid-e-usman .top-header-row {
     flex: 0 0 auto;
     display: none;
@@ -62,14 +62,21 @@
     display: flex;
 }
 
+/* Desktop only - hide top header */
+@media (min-width: 768px) {
+    .d-masjid-e-usman .top-header-row {
+        display: none !important;
+    }
+}
+
 /* Mobile only - show top, hide bottom */
 @media (max-width: 767px) {
     .d-masjid-e-usman .top-header-row {
-        display: flex;
+        display: flex !important;
     }
     
     .d-masjid-e-usman .mosque-info-overlay.desktop-only {
-        display: none;
+        display: none !important;
     }
 }
 

--- a/Assets/css/usman/style.css
+++ b/Assets/css/usman/style.css
@@ -348,12 +348,26 @@
 
 .d-masjid-e-usman .banner-section {
     margin: 0;
-    height: 100%;
-    padding: 25px 20px 0 20px;
+    height: 85%;
+    padding: 15px 20px 0 20px;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+}
+
+.d-masjid-e-usman .right-main-column {
+    display: flex;
+    flex-direction: column;
+}
+
+.d-masjid-e-usman .mosque-info-overlay {
+    flex: 0 0 auto;
+    min-height: 80px;
+}
+
+.mobile-only .banner-section {
+    height: calc(100% - 80px);
 }
 
 .d-masjid-e-usman .banner-section .carousel-item {
@@ -541,13 +555,22 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
-   MOBILE  (≤ 767px)
-═══════════════════════════════════════════════════════════════════════ */
+    MOBILE  (≤ 767px)
+   ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 767px) {
 
     /* ── Layout ── */
     .d-masjid-e-usman {
         height: auto;
+    }
+
+    .d-masjid-e-usman .banner-section {
+        height: calc(100% - 70px);
+    }
+    
+    .d-masjid-e-usman .top-header-row {
+        flex: 0 0 60px;
+        min-height: 60px;
     }
 
     /* Mobile logo — compact header strip */

--- a/Models/design/my-masjid.php
+++ b/Models/design/my-masjid.php
@@ -262,6 +262,16 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
   .prayer-table th.right-align,
   .prayer-table td.right-align { text-align: right; }
 
+  .prayer-table th:first-child,
+  .prayer-table td:first-child {
+    padding-left: clamp(6px, 2vw, 10px);
+  }
+
+  .prayer-table th:last-child,
+  .prayer-table td:last-child {
+    padding-right: clamp(6px, 2vw, 10px);
+  }
+
   .prayer-table td {
     font-size: clamp(2rem, 2.5vw, 2rem);
     font-weight: 500;
@@ -298,6 +308,11 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
     color: var(--text-main) !important;
   }
 
+  /* Mobile-only duplicate of masjid header (left panel is hidden) */
+  .masjid-header--mobile {
+    display: none;
+  }
+
   @media (max-width: 768px) {
   .left {
     display: none;
@@ -307,8 +322,107 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
     grid-template-columns: 1fr;
   }
 
-  .timeLeftCountDown, h2.dptScTime{
-    font-size: clamp(1.5rem, 2.5vw, 2rem) !important;
+  .masjid-header--mobile {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    margin: 0 0 10px;
+    padding: 0;
+    text-align: center;
+  }
+
+  .masjid-header--mobile .masjid-logo {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+  }
+
+  .masjid-header--mobile .masjid-info {
+    text-align: center;
+    min-width: 0;
+  }
+
+  .masjid-header--mobile .masjid-info h1 {
+    font-size: clamp(1rem, 4.2vw, 1.35rem);
+    line-height: 1.2;
+    word-break: break-word;
+  }
+
+  /* Tight screen margins so table can use width; column padding handles inset */
+  .right {
+    padding: 0.8vh max(4px, env(safe-area-inset-right, 0px)) 1vh max(4px, env(safe-area-inset-left, 0px));
+    justify-content: flex-start;
+  }
+
+  .next-banner {
+    margin-bottom: 0.6vh;
+    padding: 0.7vh max(4px, env(safe-area-inset-right, 0px)) 0.7vh max(4px, env(safe-area-inset-left, 0px));
+    border-radius: 8px;
+  }
+
+  .next-banner .next-name, .dptScTime {
+    font-size: clamp(0.95rem, 3.8vw, 1.2rem) !important;
+  }
+
+  .next-banner .countdown {
+    font-size: clamp(1.75rem, 8vw, 2.6rem) !important;
+    letter-spacing: -1px;
+  }
+
+  .prayer-table thead tr {
+    height: auto;
+  }
+
+  .prayer-table th {
+    font-size: clamp(1.1rem, 4.2vw, 1.4rem) !important;
+    padding: 0 0 0.35vh 0;
+    line-height: 1.15;
+  }
+
+  .prayer-table th.ar {
+    font-size: clamp(1rem, 4vw, 1.3rem) !important;
+  }
+
+  .prayer-table td {
+    font-size: clamp(1.1rem, 4.2vw, 1.4rem) !important;
+    padding: 0.28vh 0;
+    line-height: 1.15;
+  }
+
+  .prayer-table th:first-child {
+    padding-left: clamp(34px, calc(30px + 2.4vw), 48px) !important;
+  }
+
+  .prayer-table th:last-child {
+    padding-right: clamp(34px, calc(30px + 2.4vw), 48px) !important;
+  }
+
+  .prayer-table td:first-child {
+    padding-left: clamp(34px, calc(30px + 2.4vw), 48px) !important;
+  }
+
+  .prayer-table td:last-child {
+    padding-right: clamp(34px, calc(30px + 2.4vw), 48px) !important;
+  }
+
+  .prayer-table td.ar {
+    font-size: clamp(1rem, 3.8vw, 1.25rem) !important;
+  }
+
+  .prayer-table td.bold {
+    font-size: clamp(1.15rem, 4.4vw, 1.45rem) !important;
+  }
+
+  .x-board-my-masjid td span.dpt_start,
+  .x-board-my-masjid td span.dpt_jamah {
+    font-size: clamp(1.1rem, 4.2vw, 1.4rem) !important;
+  }
+
+  .timeLeftCountDown, h2.dptScTime {
+    font-size: clamp(1.65rem, 5vw, 2.2rem) !important;
   }
 }
 </style>
@@ -366,6 +480,15 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
 
   <!-- RIGHT -->
   <div class="right">
+
+    <div class="masjid-header masjid-header--mobile">
+      <div class="masjid-logo">
+      <?php echo $this->getLogoUrl(); ?>
+      </div>
+      <div class="masjid-info">
+        <h1><?php echo get_bloginfo('name'); ?></h1>
+      </div>
+    </div>
 
     <!-- Next prayer banner -->
     <?php echo $this->getHiddenVariables(); ?>

--- a/Models/design/my-masjid.php
+++ b/Models/design/my-masjid.php
@@ -257,6 +257,7 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
     color: var(--text-light);
     font-weight: 400;
     direction: rtl;
+    text-align: center;
   }
 
   .prayer-table th.right-align,

--- a/Models/design/my-masjid.php
+++ b/Models/design/my-masjid.php
@@ -289,8 +289,13 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
     font-weight: 400;
   }
 
-  .x-board td span.dpt_start, td span.dpt_jamah {
+  .x-board-my-masjid td span.dpt_start,
+  .x-board-my-masjid td span.dpt_jamah {
     font-size: clamp(2rem, 2.5vw, 2rem) !important;
+  }
+
+  .x-board-my-masjid p.hijriDate {
+    color: var(--text-main) !important;
   }
 
   @media (max-width: 768px) {
@@ -354,7 +359,7 @@ $fajrTime = isset($this->row['fajr_begins']) ? substr($this->row['fajr_begins'],
     <div class="digital">
       <div class="time" id="digitalTime">--:--</div>
       <div class="date" id="digitalDate">--</div>
-      <p><?php echo $this->getHijriDate(date("d"), date("m"), date("Y"), $this->getRow()); ?></p>
+      <p class="hijriDate"><?php echo $this->getHijriDate(date("d"), date("m"), date("Y"), $this->getRow()); ?></p>
     </div>
 
   </div>

--- a/Models/design/usman.php
+++ b/Models/design/usman.php
@@ -56,10 +56,10 @@ $html = '';
                                 <div class='col-md-4 col-sm-4 col-4 {$prayer}-title title-value'>
                                     <span class='title'>{$prayerName}</span>
                                 </div>
-                                <div class='col-md-4 col-sm-4 col-4 {$prayer}-start-time time-value'>
+                                <div class='col-md-4 col-sm-4 col-4 prayer-start-time time-value'>
                                     <h3>{$startTime}</h3>
                                 </div>
-                                <div class='col-md-4 col-sm-4 col-4 {$prayer}-jamah-time time-value'>
+                                <div class='col-md-4 col-sm-4 col-4 prayer-jamah-time time-value'>
                                     <h3>{$jamahTime}</h3>
                                 </div>
                             </div>";

--- a/Models/design/usman.php
+++ b/Models/design/usman.php
@@ -1,4 +1,5 @@
 <?php
+echo $this->getHiddenVariables();
 $html = '';
 ?>
 <!-- MASJID DESIGN -->
@@ -10,7 +11,7 @@ $html = '';
             
             </div>
         </div>
-        <div class="row height-100">
+        <div class="row">
             <!-- LEFT SIDE TIME TABLE AND INFORMATION -->
             <div class="col-md-6 col-sm-12 col-12 left-main-column">
                 <div class="row left-main-col-dateandtime">
@@ -74,7 +75,7 @@ $html = '';
                     </div>
                 </div>
 
-                <div class="row left-main-col-sun-times pt-md-3 text-center highlight">
+                <div class="row left-main-col-sun-times pt-md-3 pt-2 text-center highlight">
                     <div class="col-md-3 col-sm-3 col-3 sub-sadiq-section">
                         <p class="sub-sadiq-title">SUBH-SADIQ</p><br>
                         <h4 class="sub-sadiq-time"><?php echo do_shortcode("[fajr_start]"); ?></h4>
@@ -113,7 +114,7 @@ $html = '';
                 }
             }
             ?>
-            <div class="col-md-6 right-main-column height-100">
+            <div class="col-md-6 col-sm-12 col-12 right-main-column">
                 <div class="row banner-section">
                     <div id="carouselExampleIndicators" class="carousel slide <?php echo $transitionEffect; ?> height-100" data-bs-ride="carousel">
                         <div class="carousel-inner height-100">

--- a/Models/design/usman.php
+++ b/Models/design/usman.php
@@ -124,6 +124,14 @@ $html = '';
                         </div>
                     </div>
                 </div>
+                <div class="row mosque-info-overlay desktop-only">
+                    <div class="col-md-3 logo-section">
+                        <?php echo $this->getLogoUrl(); ?>
+                    </div>
+                    <div class="col-md-9 afterlogo-text">
+                        <h1 class="bottomright-masjidname"><?php echo get_bloginfo('name'); ?></h1>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/Models/design/usman.php
+++ b/Models/design/usman.php
@@ -5,10 +5,12 @@ $html = '';
 <!-- MASJID DESIGN -->
 <div class="usman-body">
     <div class="container-fluid d-masjid-e-usman">
-        <div class="row mobile-logo-row">
-            <div class="col-sm-12 mobile-logo-column text-center" >
+        <div class="row top-header-row">
+            <div class="col-md-3 logo-section-top">
                 <?php echo $this->getLogoUrl(); ?>
-            
+            </div>
+            <div class="col-md-9 mosque-name-top">
+                <h1><?php echo get_bloginfo('name'); ?></h1>
             </div>
         </div>
         <div class="row">
@@ -120,14 +122,6 @@ $html = '';
                         <div class="carousel-inner height-100">
                             <?php echo $slides; ?>
                         </div>
-                    </div>
-                </div>
-                <div class="row mosque-info-overlay">
-                    <div class="col-md-3 logo-section">
-                        <?php echo $this->getLogoUrl(); ?>
-                    </div>
-                    <div class="col-md-9 afterlogo-text">
-                        <h1 class="bottomright-masjidname"><?php echo get_bloginfo('name'); ?></h1>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Display Quran verse on right panel for usman template
- Simplify CSS with clamp() for responsive fonts
- Add flexbox layouts for full height utilization
- Move logo and mosque name: top on mobile, bottom on desktop
- Add decorative border around Quran verse
- Reduce spacing in prayer section on mobile
- Simplified CSS selectors for prayer times