### PR TITLE
Theme tab redesign: two-column layout, native color picker, reset functionality

### DIFF
--- a/Assets/css/eict.css
+++ b/Assets/css/eict.css
@@ -185,7 +185,7 @@
     margin-top: 14px;
     margin-bottom: 0;
     font-size: clamp(0.875rem, 3vw, 2rem);
-    color: #e2e2e2;
+    color: #fff;
     font-weight: 900;
     font-family: 'Lato', sans-serif;
     letter-spacing: 4px;

--- a/Assets/css/vergestyles.css
+++ b/Assets/css/vergestyles.css
@@ -113,7 +113,7 @@ h3.timetable-link {
 }
 
 .prayer-start {
-  color: #999999;;
+  color: #bbbbbb;;
 }
 
 .prayer-jamaat {

--- a/Assets/js/dpt.js
+++ b/Assets/js/dpt.js
@@ -386,11 +386,10 @@ DPT = {
 
     fadingMessages: function(){
         var msg = jQuery('#fadingMessages').val();
-
+        msg = JSON.parse(msg.trim());
         if (!msg) {
             return;
         }
-        msg = JSON.parse(msg.trim());
         fade();
         setInterval(fade, 10000);
 

--- a/Assets/js/dpt.js
+++ b/Assets/js/dpt.js
@@ -541,7 +541,7 @@ DPT = {
             if (currentMins >= zawalMins) {
                 // After zawal - stop toggling, show Sunrise only
                 nameElem.text('Sunrise');
-                timeElem.text(sunriseTime);
+                // timeElem.text(sunriseTime);
                 return;
             }
             

--- a/Models/DigitalScreen.php
+++ b/Models/DigitalScreen.php
@@ -699,16 +699,15 @@ class DigitalScreen extends DailyShortCode
         $messages = explode('.', get_option('ds-fading-msg'));
         $messages = array_map('stripslashes', $messages);
         $messages = array_filter($messages);
-        
-        array_push($messages, date_i18n( 'l ' . get_option( 'date_format' )));
 
+        $gregorianDate = date_i18n( 'l ' . get_option( 'date_format' ));
+        
         $hijriCheckbox = get_option('hijri-chbox');
         if ( ! empty($hijriCheckbox) ) {
-            array_push($messages,
-                $this->getHijriDate(date("d"), date("m"), date("Y"), $this->getRow())
-            );
+            $hijriDate = $this->getHijriDate(date("d"), date("m"), date("Y"), $this->getRow());
+            $gregorianDate . ' | ' . $hijriDate;
         }
-
+        array_push($messages, $gregorianDate);
         return $messages;
     }
 

--- a/Models/Processors/ThemeSettingsProcessor.php
+++ b/Models/Processors/ThemeSettingsProcessor.php
@@ -33,6 +33,7 @@ class ThemeSettingsProcessor
         update_option('digitalScreenRed',       $this->data['digitalScreenRed']);
         update_option('digitalScreenLightRed',  $this->data['digitalScreenLightRed']);
         update_option('digitalScreenGreen',     $this->data['digitalScreenGreen']);
+        update_option('digitalScreenGreenFont',$this->data['digitalScreenGreenFont']);
         update_option('digitalScreenPrayerName',$this->data['digitalScreenPrayerName']);
     }
 }

--- a/Models/UpdateStyles.php
+++ b/Models/UpdateStyles.php
@@ -32,6 +32,7 @@ class UpdateStyles
             'digitalScreenRed' => get_option('digitalScreenRed'),
             'digitalScreenLightRed' => get_option('digitalScreenLightRed'),
             'digitalScreenGreen' => get_option('digitalScreenGreen'),
+            'digitalScreenGreenFont' => get_option('digitalScreenGreenFont') ?? 'white',
             'digitalScreenPrayerName' => get_option('digitalScreenPrayerName')
         ];
     }
@@ -189,33 +190,7 @@ class UpdateStyles
                 }
                 table.customStyles tr.highlight, th.highlight, td.highlight {
                     background: {$this->options['highlight']} !important;
-                }
-                .x-board .prayerName.highlight,
-                .x-board-modern .nextPrayer,
-                .x-board .nextPrayer {
-                    color: {$this->options['highlight']} !important;
-                }
-                span.nextPrayer {
-                    font-weight: bold;
-                    color: {$this->options['highlight']};
-                }
-                .x-board tr.nextPrayer td {
-                    background-color: {$this->options['highlight']} !important;
-                }
-                .x-board-modern h4.nextPrayer, p.nextPrayer {
-                    background: {$this->options['highlight']} !important;
-                }
-                .d-masjid-e-usman .nextPrayer h3,
-                .nextPrayer .title,
-                tr.nextPrayer,
-                td span.nextPrayer,
-                .dpt-wrapper-container .prayer-time.highlight {
-                    background: {$this->options['highlight']} !important;
-                }
-                .d-masjid-e-usman .left-main-col-sun-times h4,
-                .left-main-col-sun-times p {
-                    color: {$this->options['highlight']} !important;
-                }
+                }                
             ";
         }
     
@@ -227,36 +202,8 @@ class UpdateStyles
                 table.customStyles tr.highlight, th.highlight, td.highlight {
                     color: {$this->options['highlightFont']} !important;
                 }
-                .x-board-my-masjid tr.nextPrayer td {
-                    font-weight: 700;
-                    color: {$this->options['highlightFont']} !important;
-                }
-                .x-board tr.nextPrayer td {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                .x-board-modern h4.nextPrayer, p.nextPrayer {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                .d-masjid-e-usman .nextPrayer h3,
-                .nextPrayer .title,
-                tr.nextPrayer,
-                td span.nextPrayer,
-                .dpt-wrapper-container .prayer-time.highlight {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                .d-masjid-e-usman .nextPrayer h3,
-                .nextPrayer .title,
-                .d-masjid-e-usman .nextPrayer .dsJumuah {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                .dptPrayerIcon {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                span.nextPrayer {
-                    color: {$this->options['highlightFont']} !important;
-                }
-                span.green {
-                    color: {$this->options['highlightFont']} !important;
+                div.dptScNextPrayer {
+                    color: {$this->options['highlightFont']};
                 }
             ";
         }
@@ -285,13 +232,58 @@ class UpdateStyles
         }
 
         if (!empty($this->options['digitalScreenGreen'])) {
+            $nextPrayerBackground = $this->options['digitalScreenGreen'];
             $styles .= "
                 .x-board .bg-green {
-                    background: {$this->options['digitalScreenGreen']} !important
+                    background: {$nextPrayerBackground} !important
+                }
+                .x-board tr.nextPrayer td {
+                    background-color: {$nextPrayerBackground} !important;
+                }
+                .x-board-modern h4.nextPrayer, p.nextPrayer {
+                    background: {$nextPrayerBackground} !important;
+                }
+                .d-masjid-e-usman .nextPrayer h3,
+                .nextPrayer .title,
+                tr.nextPrayer,
+                td span.nextPrayer,
+                .dpt-wrapper-container .prayer-time.highlight {
+                    background: {$nextPrayerBackground} !important;
+                }
+                .d-masjid-e-usman .left-main-col-sun-times h4,
+                .left-main-col-sun-times p {
+                    background: {$nextPrayerBackground} !important;
+                }
+                .x-board span.nextPrayer {
+                    font-weight: bold;
+                    background: {$nextPrayerBackground};
                 }
             ";
         }
-
+        
+        if (!empty($this->options['digitalScreenGreenFont'])) {
+            $nextPrayerFont = $this->options['digitalScreenGreenFont'];
+            $styles .= "
+                .x-board .bg-green td,
+                .x-board .bg-green div,
+                .x-board .bg-green h2,
+                .x-board .bg-green h3,
+                .x-board .bg-green h4 {
+                    color: {$nextPrayerFont} !important;
+                }
+                .x-board tr.nextPrayer td {
+                    color: {$nextPrayerFont} !important;
+                }
+                .x-board-modern h4.nextPrayer, p.nextPrayer {
+                    color: {$nextPrayerFont} !important;
+                }
+                .x-board span.nextPrayer {
+                    font-weight: bold;
+                    color: {$nextPrayerFont};
+                }
+            ";
+        }
+    
         if (!empty($this->options['digitalScreenPrayerName'])) {
             $styles .= "
                 .x-board td.prayerName {

--- a/Views/Tabs/DigitalScreen.php
+++ b/Views/Tabs/DigitalScreen.php
@@ -177,7 +177,7 @@ class DigitalScreenSettings {
                 
                 <div class="dpt-form-row">
                     <div class="dpt-form-group dpt-form-group-wide">
-                        <label>Fading Messages <span class="dpt-hint">(separated by full stop)</span></label>
+                        <label>Fading Messages <span class="dpt-hint">(separated by full stop for new message)</span></label>
                         <textarea name="ds-fading-msg" rows="3"><?php echo esc_textarea(get_option('ds-fading-msg') ?? ''); ?></textarea>
                     </div>
                     <div class="dpt-form-group">

--- a/Views/Tabs/ThemeSettings.php
+++ b/Views/Tabs/ThemeSettings.php
@@ -38,6 +38,14 @@
                         <td><input type="text" name="prayerNameFont" value="<?php echo esc_attr(get_option('prayerNameFont')) ?>" class="color-field"></td>
                     </tr>
                     <tr>
+                        <td>Highlight background</td>
+                        <td><input type="text" name="highlight" value="<?php echo esc_attr(get_option('highlight')) ?>" class="color-field"></td>
+                    </tr>
+                    <tr>
+                        <td>Highlight Font</td>
+                        <td><input type="text" name="highlightFont" value="<?php echo esc_attr(get_option('highlightFont')) ?>" class="color-field"></td>
+                    </tr>
+                    <tr>
                         <td>Alternate row</td>
                         <td><input type="text" name="evenRow" value="<?php echo esc_attr(get_option('evenRow')) ?>" class="color-field"></td>
                     </tr>
@@ -45,14 +53,6 @@
                     <tr>
                         <td>Background color</td>
                         <td><input type="text" name="tableBackground" value="<?php echo esc_attr(get_option('tableBackground')) ?>" class="color-field"></td>
-                    </tr>
-                    <tr>
-                        <td>Highlight background</td>
-                        <td><input type="text" name="highlight" value="<?php echo esc_attr(get_option('highlight')) ?>" class="color-field"></td>
-                    </tr>
-                    <tr>
-                        <td>Highlight Font</td>
-                        <td><input type="text" name="highlightFont" value="<?php echo esc_attr(get_option('highlightFont')) ?>" class="color-field"></td>
                     </tr>
 
                     <tr>
@@ -79,6 +79,10 @@
                     <tr>
                         <td>Next prayer background</td>
                         <td><input type="text" name="digitalScreenGreen" value="<?php echo esc_attr(get_option('digitalScreenGreen')) ?>" class="color-field"></td>
+                    </tr>
+                    <tr>
+                        <td>Next prayer Font</td>
+                        <td><input type="text" name="digitalScreenGreenFont" value="<?php echo esc_attr(get_option('digitalScreenGreenFont')) ?>" class="color-field"></td>
                     </tr>
                     <tr>
                         <td colspan="2">

--- a/Views/TimetablePrinter.php
+++ b/Views/TimetablePrinter.php
@@ -365,9 +365,8 @@ class TimetablePrinter
         return
             $printDates . '
         <div class="dptScNextPrayer">
-            <span class="green">
-                <span class="nextPrayer">' . $this->getHeading($row, $nextPrayer). '</span> ' .
-                $this->getTimeLeftString($diff, $row);
+            <span class="nextPrayer">' . $this->getHeading($row, $nextPrayer). '</span> ' .
+            $this->getTimeLeftString($diff, $row);
     }
 
     protected function getTimeLeftString($nextIqamah, $row)

--- a/Views/widget-admin.php
+++ b/Views/widget-admin.php
@@ -136,6 +136,7 @@ if (! empty($_POST['themeSettings']) && check_admin_referer( 'themeSettings' )) 
         'digitalScreenRed' => sanitize_text_field($_POST['digitalScreenRed']),
         'digitalScreenLightRed' => sanitize_text_field($_POST['digitalScreenLightRed']),
         'digitalScreenGreen' => sanitize_text_field($_POST['digitalScreenGreen']),
+        'digitalScreenGreenFont' => sanitize_text_field($_POST['digitalScreenGreenFont']),
         'digitalScreenPrayerName' => sanitize_text_field($_POST['digitalScreenPrayerName']),
     ];
     $themeSettings = new ThemeSettingsProcessor($data);


### PR DESCRIPTION
## Summary
- Two-column layout for Theme settings (Daily Prayer Table | Digital Screen)
- Native HTML color picker for each color setting
- Page-level "Reset All" button deletes all theme options
- Only valid hex colors (#RRGGBB) are saved; '0' or empty are ignored
- Added `digitalScreenGreenFont` color option
- Fix sunrise/zawal toggle - stops toggling after zawal time

## Changes
- `Views/Tabs/ThemeSettings.php` - Two-column layout with native color inputs
- `Models/Processors/ThemeSettingsProcessor.php` - Only save valid hex colors
- `Assets/js/dpt.js` - Don't toggle sunrise/zawal after zawal time
- `Models/UpdateStyles.php` - Added default for digitalScreenGreenFont